### PR TITLE
fix(security): close platform authorization and tenant isolation gaps

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/AdminGatewayController.php
+++ b/backend/app/Http/Controllers/Api/Admin/AdminGatewayController.php
@@ -8,9 +8,16 @@ use App\Http\Requests\UpdateGatewayRequest;
 use App\Http\Resources\GatewayResource;
 use App\Models\Gateway;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * API controller for managing SIP gateways globally across all organizations.
+ *
+ * This controller deliberately crosses organization boundaries: index lists
+ * every tenant's gateways and store accepts an arbitrary organization_id. It is
+ * therefore restricted to platform admins. Organization-scoped gateway access
+ * belongs on Api\GatewayController, which is nested under
+ * organizations/{organization} and filtered accordingly.
  */
 class AdminGatewayController extends Controller
 {
@@ -19,6 +26,7 @@ class AdminGatewayController extends Controller
      */
     public function index()
     {
+        Gate::authorize('platform-admin');
         $this->authorize('viewAny', Gateway::class);
 
         return GatewayResource::collection(Gateway::with('organization')->orderByDesc('id')->paginate(20));
@@ -29,6 +37,7 @@ class AdminGatewayController extends Controller
      */
     public function store(StoreGatewayRequest $request): JsonResponse
     {
+        Gate::authorize('platform-admin');
         $this->authorize('create', Gateway::class);
 
         // Required logic requires organization_id from the JSON payload.
@@ -42,6 +51,7 @@ class AdminGatewayController extends Controller
      */
     public function show(Gateway $gateway): JsonResponse|GatewayResource
     {
+        Gate::authorize('platform-admin');
         $this->authorize('view', $gateway);
 
         return new GatewayResource($gateway);
@@ -52,6 +62,7 @@ class AdminGatewayController extends Controller
      */
     public function update(UpdateGatewayRequest $request, Gateway $gateway): JsonResponse|GatewayResource
     {
+        Gate::authorize('platform-admin');
         $this->authorize('update', $gateway);
 
         $gateway->update($request->validated());
@@ -64,6 +75,7 @@ class AdminGatewayController extends Controller
      */
     public function destroy(Gateway $gateway): JsonResponse
     {
+        Gate::authorize('platform-admin');
         $this->authorize('delete', $gateway);
 
         $gateway->delete();

--- a/backend/app/Http/Controllers/Api/CallController.php
+++ b/backend/app/Http/Controllers/Api/CallController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\CallDeliveryAttempt;
 use App\Models\CallSession;
 use App\Models\Organization;
 use App\Services\Call\OutboundOriginateService;
@@ -154,13 +155,24 @@ class CallController extends Controller
             $rows,
         )));
 
-        $ownedUuids = $uuids === []
-            ? []
-            : CallSession::query()
+        if ($uuids === []) {
+            $ownedUuids = [];
+        } else {
+            $ownedUuids = CallSession::query()
                 ->where('organization_id', $organization->id)
                 ->whereIn('call_uuid', $uuids)
                 ->pluck('call_uuid')
                 ->all();
+
+            // Delivered legs have their own channel UUID, so a B-leg belonging
+            // to this organization is attributable even though it is not the
+            // session's call_uuid.
+            $ownedUuids = array_merge($ownedUuids, CallDeliveryAttempt::query()
+                ->whereIn('freeswitch_leg_uuid', $uuids)
+                ->whereHas('callSession', fn ($query) => $query->where('organization_id', $organization->id))
+                ->pluck('freeswitch_leg_uuid')
+                ->all());
+        }
 
         $ownedUuids = array_flip($ownedUuids);
         $domain = (string) $organization->domain;
@@ -198,9 +210,23 @@ class CallController extends Controller
      */
     protected function organizationOwnsCall(Organization $organization, string $callUuid): bool
     {
-        return CallSession::query()
+        $ownsSession = CallSession::query()
             ->where('organization_id', $organization->id)
             ->where('call_uuid', $callUuid)
+            ->exists();
+
+        if ($ownsSession) {
+            return true;
+        }
+
+        // A call delivered to a SIP or PSTN endpoint has a distinct B-leg
+        // channel, and that leg UUID — not the session's call_uuid — is what a
+        // supervisor acts on when hanging up or recording the answered leg. It
+        // is surfaced to clients as winner.leg_uuid, so it has to be accepted
+        // here or legitimate control of an answered call would 404.
+        return CallDeliveryAttempt::query()
+            ->where('freeswitch_leg_uuid', $callUuid)
+            ->whereHas('callSession', fn ($query) => $query->where('organization_id', $organization->id))
             ->exists();
     }
 

--- a/backend/app/Http/Controllers/Api/CallController.php
+++ b/backend/app/Http/Controllers/Api/CallController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\CallSession;
 use App\Models\Organization;
 use App\Services\Call\OutboundOriginateService;
 use App\Services\EslConnectionManager;
@@ -31,7 +32,15 @@ class CallController extends Controller
         $validated = $request->validate([
             'extension' => 'required|string',
             'destination' => 'required|string',
-            'caller_id_name' => 'nullable|string',
+            // Both halves of the presented caller ID are derived server-side.
+            // The number comes from the extension's allowed outbound DIDs, and
+            // the name from its configured caller-ID name — a client-supplied
+            // display name would let any caller present an arbitrary identity
+            // ("IRS", a colleague's name) on the PSTN, which the DID allow-list
+            // is there to prevent.
+            'caller_id_name' => [
+                'prohibited',
+            ],
             'caller_id_number' => [
                 'prohibited',
             ],
@@ -75,7 +84,6 @@ class CallController extends Controller
                 organization: $organization,
                 extension: $extension,
                 destination: $validated['destination'],
-                callerIdName: $validated['caller_id_name'] ?? null,
                 didId: $validated['did_id'] ?? null,
                 gatewayId: $validated['gateway_id'] ?? null,
             );
@@ -98,7 +106,14 @@ class CallController extends Controller
     }
 
     /**
-     * Get active channels/calls status.
+     * Get active channels/calls status for this organization.
+     *
+     * FreeSWITCH is shared by every tenant, so `show channels` reports the whole
+     * switch. Rows are filtered down to channels attributable to this
+     * organization — either by a CallSession record or by the dialplan context,
+     * which is keyed on the organization domain. Filtering is deliberately
+     * inclusive-by-evidence: a channel we cannot attribute is omitted rather
+     * than shown, since the alternative leaks other tenants' call metadata.
      */
     public function status(Organization $organization): JsonResponse
     {
@@ -113,11 +128,80 @@ class CallController extends Controller
         $esl->disconnect();
 
         $channels = json_decode($response ?? '{}', true);
+        $rows = is_array($channels['rows'] ?? null) ? $channels['rows'] : [];
+        $rows = $this->channelsForOrganization($organization, $rows);
 
         return response()->json([
-            'channels' => $channels['rows'] ?? [],
-            'count' => $channels['row_count'] ?? 0,
+            'channels' => $rows,
+            'count' => count($rows),
         ]);
+    }
+
+    /**
+     * Filter raw `show channels` rows down to one organization.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @return list<array<string, mixed>>
+     */
+    protected function channelsForOrganization(Organization $organization, array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        $uuids = array_values(array_filter(array_map(
+            static fn ($row): ?string => is_array($row) ? ($row['uuid'] ?? null) : null,
+            $rows,
+        )));
+
+        $ownedUuids = $uuids === []
+            ? []
+            : CallSession::query()
+                ->where('organization_id', $organization->id)
+                ->whereIn('call_uuid', $uuids)
+                ->pluck('call_uuid')
+                ->all();
+
+        $ownedUuids = array_flip($ownedUuids);
+        $domain = (string) $organization->domain;
+
+        return array_values(array_filter($rows, static function ($row) use ($ownedUuids, $domain): bool {
+            if (! is_array($row)) {
+                return false;
+            }
+
+            if (isset($row['uuid']) && isset($ownedUuids[$row['uuid']])) {
+                return true;
+            }
+
+            if ($domain === '') {
+                return false;
+            }
+
+            if (($row['context'] ?? null) === $domain) {
+                return true;
+            }
+
+            $presenceId = (string) ($row['presence_id'] ?? '');
+
+            return $presenceId !== '' && str_ends_with($presenceId, '@'.$domain);
+        }));
+    }
+
+    /**
+     * Resolve a channel UUID that this organization is allowed to control.
+     *
+     * Returns null when the UUID has no CallSession for this organization, which
+     * callers translate into a 404. Without this check any authenticated user
+     * could hang up, transfer, hold, or start recording another tenant's call
+     * simply by naming its UUID.
+     */
+    protected function organizationOwnsCall(Organization $organization, string $callUuid): bool
+    {
+        return CallSession::query()
+            ->where('organization_id', $organization->id)
+            ->where('call_uuid', $callUuid)
+            ->exists();
     }
 
     /**
@@ -131,6 +215,10 @@ class CallController extends Controller
             'uuid' => 'required|string|max:255',
             'cause' => 'nullable|string|max:100',
         ]);
+
+        if (! $this->organizationOwnsCall($organization, $validated['uuid'])) {
+            return response()->json(['message' => 'Call not found for this organization.'], 404);
+        }
 
         $esl = app(EslConnectionManager::class);
 
@@ -161,6 +249,10 @@ class CallController extends Controller
             'leg' => 'nullable|string|in:aleg,bleg,both',
         ]);
 
+        if (! $this->organizationOwnsCall($organization, $validated['uuid'])) {
+            return response()->json(['message' => 'Call not found for this organization.'], 404);
+        }
+
         $esl = app(EslConnectionManager::class);
 
         if (! $esl->connect()) {
@@ -190,6 +282,10 @@ class CallController extends Controller
             'action' => 'required|string|in:start,stop',
         ]);
 
+        if (! $this->organizationOwnsCall($organization, $validated['uuid'])) {
+            return response()->json(['message' => 'Call not found for this organization.'], 404);
+        }
+
         $response = $validated['action'] === 'start'
             ? $this->answeredRecordingStarter->startForCall($organization->id, $validated['uuid'])
             : $this->answeredRecordingStarter->stopForCall($organization->id, $validated['uuid']);
@@ -211,6 +307,10 @@ class CallController extends Controller
             'uuid' => 'required|string|max:255',
             'action' => 'required|string|in:hold,unhold',
         ]);
+
+        if (! $this->organizationOwnsCall($organization, $validated['uuid'])) {
+            return response()->json(['message' => 'Call not found for this organization.'], 404);
+        }
 
         $esl = app(EslConnectionManager::class);
 

--- a/backend/app/Http/Controllers/Api/CallSessionController.php
+++ b/backend/app/Http/Controllers/Api/CallSessionController.php
@@ -19,8 +19,8 @@ class CallSessionController extends Controller
      */
     public function index(Organization $organization)
     {
-        // Assuming Gate::authorize('viewAny', CallSession::class) logic can be wired later
-        // Currently keeping it simple and organization scoped
+        $this->authorize('viewAny', CallSession::class);
+
         return CallSessionResource::collection(
             $organization->callSessions()
                 ->with([
@@ -36,6 +36,8 @@ class CallSessionController extends Controller
      */
     public function show(Organization $organization, CallSession $callSession): JsonResponse|CallSessionResource
     {
+        $this->authorize('view', $callSession);
+
         if ($callSession->organization_id !== $organization->id) {
             return response()->json(['message' => 'Call session not found.'], 404);
         }
@@ -65,6 +67,8 @@ class CallSessionController extends Controller
      */
     public function analyze(Organization $organization, CallSession $callSession, CallTraceAnalyzer $analyzer): JsonResponse
     {
+        $this->authorize('view', $callSession);
+
         if ($callSession->organization_id !== $organization->id) {
             return response()->json(['message' => 'Call session not found.'], 404);
         }
@@ -84,7 +88,7 @@ class CallSessionController extends Controller
         ]);
 
         return response()->json([
-            'data' => $analyzer->analyze($callSession)
+            'data' => $analyzer->analyze($callSession),
         ]);
     }
 }

--- a/backend/app/Http/Controllers/Api/CallSessionController.php
+++ b/backend/app/Http/Controllers/Api/CallSessionController.php
@@ -19,7 +19,7 @@ class CallSessionController extends Controller
      */
     public function index(Organization $organization)
     {
-        $this->authorize('viewAny', CallSession::class);
+        $this->authorize('viewAny', [CallSession::class, $organization]);
 
         return CallSessionResource::collection(
             $organization->callSessions()
@@ -36,11 +36,14 @@ class CallSessionController extends Controller
      */
     public function show(Organization $organization, CallSession $callSession): JsonResponse|CallSessionResource
     {
-        $this->authorize('view', $callSession);
-
+        // Order matters: answer 404 for anything outside this organization before
+        // authorizing, otherwise a foreign session returns 403 while an unknown
+        // one returns 404 — an existence oracle for other tenants' session IDs.
         if ($callSession->organization_id !== $organization->id) {
             return response()->json(['message' => 'Call session not found.'], 404);
         }
+
+        $this->authorize('view', $callSession);
 
         $callSession->load([
             'traceEvents' => function ($query) {
@@ -67,11 +70,14 @@ class CallSessionController extends Controller
      */
     public function analyze(Organization $organization, CallSession $callSession, CallTraceAnalyzer $analyzer): JsonResponse
     {
-        $this->authorize('view', $callSession);
-
+        // Order matters: answer 404 for anything outside this organization before
+        // authorizing, otherwise a foreign session returns 403 while an unknown
+        // one returns 404 — an existence oracle for other tenants' session IDs.
         if ($callSession->organization_id !== $organization->id) {
             return response()->json(['message' => 'Call session not found.'], 404);
         }
+
+        $this->authorize('view', $callSession);
 
         $callSession->load([
             'deliveryAttempts' => function ($query) {

--- a/backend/app/Http/Controllers/Api/ExtensionController.php
+++ b/backend/app/Http/Controllers/Api/ExtensionController.php
@@ -7,13 +7,13 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreExtensionRequest;
 use App\Http\Requests\UpdateExtensionRequest;
 use App\Http\Resources\ExtensionResource;
+use App\Models\DeviceProfile;
 use App\Models\Extension;
 use App\Models\Organization;
-use App\Models\DeviceProfile;
 use App\Services\ExtensionFeatureService;
 use App\Services\OrganizationManifestBuilder;
-use App\Services\WebRtcConfigService;
 use App\Services\WebhookDispatcher;
+use App\Services\WebRtcConfigService;
 use Illuminate\Http\JsonResponse;
 use InvalidArgumentException;
 
@@ -76,7 +76,9 @@ class ExtensionController extends Controller
         }
 
         $this->syncOutboundPolicy($extension, $allowedOutboundDidIds, $allowedOutboundGatewayIds);
-        $this->syncOwnedDevice($extension, $attributes['device_profile_id'] ?? null);
+        if (($attributes['device_profile_id'] ?? null) !== null) {
+            $this->syncOwnedDevice($extension, $attributes['device_profile_id']);
+        }
 
         $this->webhookDispatcher->dispatch($organization->id, 'extension.created', [
             'extension_id' => $extension->id,
@@ -118,6 +120,7 @@ class ExtensionController extends Controller
         unset($attributes['allowed_outbound_did_ids'], $attributes['allowed_outbound_gateway_ids']);
 
         $oldExtensionNumber = $extension->extension;
+        $originalDeviceProfileId = $extension->device_profile_id;
 
         try {
             $extension->update($attributes);
@@ -130,7 +133,14 @@ class ExtensionController extends Controller
         }
 
         $this->syncOutboundPolicy($extension, $allowedOutboundDidIds, $allowedOutboundGatewayIds);
-        $this->syncOwnedDevice($extension, $attributes['device_profile_id'] ?? null);
+        // Reconcile the reverse link only when this extension's own
+        // device_profile_id actually changed. The admin form always submits the
+        // field — null for a user-owned extension — so acting on its value
+        // alone would unlink a phone assigned from the Devices page on any
+        // unrelated edit.
+        if ($extension->device_profile_id !== $originalDeviceProfileId) {
+            $this->syncOwnedDevice($extension, $extension->device_profile_id);
+        }
 
         if ((($attributes['extension'] ?? null) !== null && $oldExtensionNumber !== $extension->extension)
             || array_key_exists('is_active', $attributes)) {

--- a/backend/app/Http/Controllers/Api/SipProfileController.php
+++ b/backend/app/Http/Controllers/Api/SipProfileController.php
@@ -6,16 +6,29 @@ use App\Http\Controllers\Controller;
 use App\Models\SipProfile;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Gate;
 
+/**
+ * Manages global FreeSWITCH SIP profiles.
+ *
+ * SIP profiles are platform-level objects shared by every organization, and
+ * saving one restarts the corresponding sofia profile (see SipProfileSetting),
+ * which drops registrations for all tenants. Every action is therefore gated on
+ * the platform-admin ability rather than on organization-scoped permissions.
+ */
 class SipProfileController extends Controller
 {
     public function index()
     {
+        Gate::authorize('platform-admin');
+
         return SipProfile::with('settings')->orderByDesc('id')->get();
     }
 
     public function store(Request $request)
     {
+        Gate::authorize('platform-admin');
+
         $validated = $request->validate([
             'name' => 'required|string|unique:sip_profiles,name',
             'hostname' => 'nullable|string',
@@ -48,13 +61,17 @@ class SipProfileController extends Controller
 
     public function show(SipProfile $sipProfile)
     {
+        Gate::authorize('platform-admin');
+
         return $sipProfile->load('settings');
     }
 
     public function update(Request $request, SipProfile $sipProfile)
     {
+        Gate::authorize('platform-admin');
+
         $validated = $request->validate([
-            'name' => 'sometimes|string|unique:sip_profiles,name,' . $sipProfile->id,
+            'name' => 'sometimes|string|unique:sip_profiles,name,'.$sipProfile->id,
             'hostname' => 'nullable|string',
             'description' => 'nullable|string',
             'is_active' => 'boolean',
@@ -65,7 +82,7 @@ class SipProfileController extends Controller
             'settings.*.is_enabled' => 'boolean',
             'settings.*.description' => 'nullable|string',
             'settings_to_delete' => 'array',
-            'settings_to_delete.*' => 'uuid'
+            'settings_to_delete.*' => 'uuid',
         ]);
 
         $this->validateWebRtcSettings($validated['settings'] ?? []);
@@ -78,7 +95,7 @@ class SipProfileController extends Controller
         ]);
 
         // Delete requested settings
-        if (!empty($validated['settings_to_delete'])) {
+        if (! empty($validated['settings_to_delete'])) {
             $sipProfile->settings()->whereIn('id', $validated['settings_to_delete'])->delete();
         }
 
@@ -102,6 +119,8 @@ class SipProfileController extends Controller
 
     public function destroy(SipProfile $sipProfile)
     {
+        Gate::authorize('platform-admin');
+
         $sipProfile->delete();
 
         return response()->noContent();

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -108,7 +108,16 @@ class UserController extends Controller
             $validated['password'] = Hash::make($validated['password']);
         }
 
+        $previousRole = $user->role;
         $user->update($validated);
+
+        // Demoting an admin to agent moves them from bypassing permission checks
+        // to being subject to them. Admins usually hold no pivot rows precisely
+        // because they bypassed the checks, so without this the demoted account
+        // would end up with no permissions at all instead of the agent baseline.
+        if ($previousRole !== $user->role) {
+            $user->grantRoleBaselinePermissions();
+        }
 
         return new UserResource($user->fresh()->load('organization'));
     }

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -77,6 +77,10 @@ class UserController extends Controller
             'organization_id' => $organizationId,
         ]);
 
+        // Permissions are deny-by-default, so a new non-admin user needs its
+        // role baseline or it lands with no access at all.
+        $user->grantRoleBaselinePermissions();
+
         return response()->json(new UserResource($user), 201);
     }
 

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -70,7 +70,6 @@ class User extends Authenticatable
         return $this->belongsTo(HolidayCalendar::class);
     }
 
-
     public function effectiveSchedule(): ?Schedule
     {
         return $this->schedule ?: $this->organization?->defaultSchedule;
@@ -101,7 +100,6 @@ class User extends Authenticatable
         return $this->hasMany(DeviceProfile::class);
     }
 
-
     public function isSuperadmin(): bool
     {
         return $this->role === 'superadmin';
@@ -118,19 +116,67 @@ class User extends Authenticatable
     }
 
     /**
+     * Baseline permissions granted to a role when a user is created.
+     *
+     * Deliberately minimal. Because no policy narrows visibility below the
+     * organization yet, every grant here is organization-wide — so this list
+     * excludes anything that would expose one colleague's content to another
+     * (recordings, CDRs, audit logs) and everything that mutates configuration.
+     * Widen it only alongside own/team scoping.
+     *
+     * @var array<string, list<string>>
+     */
+    public const ROLE_BASELINE_PERMISSIONS = [
+        'agent' => [
+            'extensions.view',
+            'calls.originate',
+            'queues.view',
+            'agents.view',
+        ],
+    ];
+
+    /**
+     * Baseline permission slugs for a role, or an empty list if it has none.
+     *
+     * @return list<string>
+     */
+    public static function baselinePermissionsFor(?string $role): array
+    {
+        return self::ROLE_BASELINE_PERMISSIONS[$role] ?? [];
+    }
+
+    /**
+     * Grant this user's role baseline.
+     *
+     * Slugs absent from the permissions table are skipped rather than failing —
+     * some baseline slugs are contributed by optional modules, so the set
+     * legitimately varies with which modules are enabled.
+     */
+    public function grantRoleBaselinePermissions(): void
+    {
+        $slugs = self::baselinePermissionsFor($this->role);
+
+        if ($slugs === []) {
+            return;
+        }
+
+        $this->grantPermissions($slugs);
+    }
+
+    /**
      * Check if the user has a specific permission by slug.
-     * Admins always have all permissions.
-     * If no permissions have been assigned to the user yet, allow all (default-open).
-     * Once any permission is explicitly granted, only those permissions are allowed.
+     *
+     * Deny-by-default: a user holds exactly the permissions granted to them.
+     * Superadmins and organization admins bypass the check entirely.
+     *
+     * Note this was previously default-open — a user with no grants was allowed
+     * everything, so permissions subtracted rather than added and a new agent
+     * silently held every permission in their organization. New users now
+     * receive their role baseline at creation (see grantRoleBaselinePermissions).
      */
     public function hasPermission(string $slug): bool
     {
         if ($this->isSuperadmin() || $this->isAdmin()) {
-            return true;
-        }
-
-        // If no permissions have been assigned to this user, default to allow
-        if ($this->permissions()->count() === 0) {
             return true;
         }
 

--- a/backend/app/Policies/CallSessionPolicy.php
+++ b/backend/app/Policies/CallSessionPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\CallSession;
+use App\Models\Organization;
 use App\Models\User;
 
 /**
@@ -23,9 +24,15 @@ class CallSessionPolicy
         return null;
     }
 
-    public function viewAny(User $user): bool
+    /**
+     * `EnsureOrganizationAccess` already rejects a tenant user who requests
+     * another organization's route, so this is defence in depth rather than the
+     * only barrier — but the whole point of this class is to not depend on a
+     * single layer, so the requested organization is checked here too.
+     */
+    public function viewAny(User $user, Organization $organization): bool
     {
-        return $user->organization_id !== null
+        return $user->organization_id === $organization->id
             && $user->hasPermission('cdrs.view');
     }
 

--- a/backend/app/Policies/CallSessionPolicy.php
+++ b/backend/app/Policies/CallSessionPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\CallSession;
+use App\Models\User;
+
+/**
+ * Authorizes access to call sessions and their trace data.
+ *
+ * Call sessions carry the same sensitivity as call detail records — who called
+ * whom, when, and which endpoint answered — so they share the `cdrs.view`
+ * permission rather than introducing a parallel slug.
+ */
+class CallSessionPolicy
+{
+    public function before(User $user, string $ability): ?bool
+    {
+        if ($user->isSuperadmin()) {
+            return true;
+        }
+
+        return null;
+    }
+
+    public function viewAny(User $user): bool
+    {
+        return $user->organization_id !== null
+            && $user->hasPermission('cdrs.view');
+    }
+
+    public function view(User $user, CallSession $callSession): bool
+    {
+        return $user->organization_id === $callSession->organization_id
+            && $user->hasPermission('cdrs.view');
+    }
+}

--- a/backend/app/Services/SipProfileCompiler.php
+++ b/backend/app/Services/SipProfileCompiler.php
@@ -17,25 +17,25 @@ class SipProfileCompiler
             $query->where('is_enabled', true);
         }])->where('is_active', true)->get();
 
-        $storagePath = storage_path('app/freeswitch/sip_profiles');
-        
-        if (!File::exists($storagePath)) {
+        $storagePath = (string) config('telephony.sip_profile_provisioning.directory', storage_path('app/freeswitch/sip_profiles'));
+
+        if (! File::exists($storagePath)) {
             File::makeDirectory($storagePath, 0755, true);
         }
 
         // Clean out existing .xml files
-        $existingFiles = File::glob($storagePath . '/*.xml');
+        $existingFiles = File::glob($storagePath.'/*.xml');
         foreach ($existingFiles as $file) {
             File::delete($file);
         }
 
         foreach ($profiles as $profile) {
             $xml = $this->compileProfileXml($profile);
-            File::put($storagePath . '/' . $profile->name . '.xml', $xml);
+            File::put($storagePath.'/'.$profile->name.'.xml', $xml);
         }
 
-        $externalGatewayPath = $storagePath . '/external';
-        if (!File::exists($externalGatewayPath)) {
+        $externalGatewayPath = $storagePath.'/external';
+        if (! File::exists($externalGatewayPath)) {
             File::makeDirectory($externalGatewayPath, 0755, true);
         }
     }
@@ -47,7 +47,7 @@ class SipProfileCompiler
     {
         $safeName = htmlspecialchars($profile->name, ENT_QUOTES | ENT_XML1);
         $xml = '<profile name="'.$safeName.'">'."\n";
-        
+
         $xml .= '  <aliases>'."\n";
         $xml .= '  </aliases>'."\n";
 

--- a/backend/config/telephony.php
+++ b/backend/config/telephony.php
@@ -144,7 +144,6 @@ return [
         ],
     ],
 
-
     /*
     |--------------------------------------------------------------------------
     | WebRTC Configuration (System-Wide)
@@ -171,6 +170,14 @@ return [
     'gateway_provisioning' => [
         'profile' => env('FREESWITCH_GATEWAY_PROFILE', 'external'),
         'external_directory' => env('FREESWITCH_GATEWAY_DIRECTORY', storage_path('app/freeswitch/sip_profiles/external')),
+    ],
+
+    'sip_profile_provisioning' => [
+        // Where compiled SIP profile XML is written for FreeSWITCH to read.
+        // Overridable so the test suite does not rewrite the checked-in
+        // profiles under storage/app — saving any SipProfile recompiles every
+        // profile to disk, which otherwise leaves the working tree dirty.
+        'directory' => env('FREESWITCH_SIP_PROFILE_DIRECTORY', storage_path('app/freeswitch/sip_profiles')),
     ],
 
     'xml_cdr' => [
@@ -212,17 +219,17 @@ return [
     */
     'push' => [
         'apns' => [
-            'key_id'           => env('APNS_KEY_ID'),
-            'team_id'          => env('APNS_TEAM_ID'),
-            'private_key'      => env('APNS_PRIVATE_KEY'),
+            'key_id' => env('APNS_KEY_ID'),
+            'team_id' => env('APNS_TEAM_ID'),
+            'private_key' => env('APNS_PRIVATE_KEY'),
             'private_key_path' => env('APNS_PRIVATE_KEY_PATH'),
-            'bundle_id'        => env('APNS_BUNDLE_ID'),
-            'production'       => (bool) env('APNS_PRODUCTION', true),
+            'bundle_id' => env('APNS_BUNDLE_ID'),
+            'production' => (bool) env('APNS_PRODUCTION', true),
         ],
         'fcm' => [
-            'project_id'            => env('FCM_PROJECT_ID'),
-            'service_account_json'  => env('FCM_SERVICE_ACCOUNT_JSON'),
-            'service_account_path'  => env('FCM_SERVICE_ACCOUNT_PATH'),
+            'project_id' => env('FCM_PROJECT_ID'),
+            'service_account_json' => env('FCM_SERVICE_ACCOUNT_JSON'),
+            'service_account_path' => env('FCM_SERVICE_ACCOUNT_PATH'),
         ],
     ],
 ];

--- a/backend/database/migrations/2026_05_09_120000_backfill_role_baseline_permissions.php
+++ b/backend/database/migrations/2026_05_09_120000_backfill_role_baseline_permissions.php
@@ -1,6 +1,5 @@
 <?php
 
-use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
@@ -17,9 +16,28 @@ use Illuminate\Support\Facades\DB;
  */
 return new class extends Migration
 {
+    /**
+     * Snapshot of the role baselines at the time this migration was written.
+     *
+     * Deliberately not User::ROLE_BASELINE_PERMISSIONS: a migration must grant
+     * what it meant on the day it was authored. Reading the live constant would
+     * let a later baseline change retroactively alter what a delayed deployment
+     * grants to existing users.
+     *
+     * @var array<string, list<string>>
+     */
+    private const ROLE_BASELINE_PERMISSIONS = [
+        'agent' => [
+            'extensions.view',
+            'calls.originate',
+            'queues.view',
+            'agents.view',
+        ],
+    ];
+
     public function up(): void
     {
-        foreach (User::ROLE_BASELINE_PERMISSIONS as $role => $slugs) {
+        foreach (self::ROLE_BASELINE_PERMISSIONS as $role => $slugs) {
             $permissionIds = DB::table('permissions')
                 ->whereIn('slug', $slugs)
                 ->pluck('id');

--- a/backend/database/migrations/2026_05_09_120000_backfill_role_baseline_permissions.php
+++ b/backend/database/migrations/2026_05_09_120000_backfill_role_baseline_permissions.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfill role baseline permissions for users who hold no explicit grants.
+ *
+ * User::hasPermission() used to be default-open: a user with zero permission
+ * rows was allowed every permission. It is now deny-by-default, which would
+ * otherwise leave every pre-existing agent with no access at all. This grants
+ * such users their role baseline so the change is not silently destructive.
+ *
+ * Users who already hold explicit grants are left untouched — their permission
+ * set was already authoritative under the old behavior.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach (User::ROLE_BASELINE_PERMISSIONS as $role => $slugs) {
+            $permissionIds = DB::table('permissions')
+                ->whereIn('slug', $slugs)
+                ->pluck('id');
+
+            if ($permissionIds->isEmpty()) {
+                continue;
+            }
+
+            $userIds = DB::table('users')
+                ->where('role', $role)
+                ->whereNotExists(function ($query) {
+                    $query->select(DB::raw(1))
+                        ->from('permission_user')
+                        ->whereColumn('permission_user.user_id', 'users.id');
+                })
+                ->pluck('id');
+
+            foreach ($userIds as $userId) {
+                foreach ($permissionIds as $permissionId) {
+                    DB::table('permission_user')->insertOrIgnore([
+                        'user_id' => $userId,
+                        'permission_id' => $permissionId,
+                    ]);
+                }
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Not reversible: the backfilled grants are indistinguishable from
+        // grants an administrator made deliberately, so removing them could
+        // revoke intended access. Left in place on rollback.
+    }
+};

--- a/backend/docker/app/entrypoint.sh
+++ b/backend/docker/app/entrypoint.sh
@@ -46,6 +46,13 @@ if [ -n "$DB_HOST" ]; then
     echo "[entrypoint] Running pending migrations..."
     php artisan migrate --force --no-interaction 2>&1 || echo "[entrypoint] Migration failed — continuing anyway"
 
+    # Permissions are deny-by-default, so the permissions table must be
+    # populated before any non-admin user is created — otherwise their role
+    # baseline has no rows to attach and they land with no access at all.
+    # Matches what install.sh already does for bare-metal deployments.
+    echo "[entrypoint] Syncing permissions..."
+    php artisan nizam:sync-permissions --no-interaction 2>&1 || echo "[entrypoint] Permission sync failed — continuing anyway"
+
     if [ -n "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
         echo "[entrypoint] ADMIN_EMAIL + ADMIN_PASSWORD set — running seeders..."
         php artisan db:seed --force --no-interaction 2>&1 || echo "[entrypoint] Seeding failed — continuing anyway"

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -33,5 +33,6 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <env name="FREESWITCH_GATEWAY_DIRECTORY" value="storage/framework/testing/gateways"/>
+        <env name="FREESWITCH_SIP_PROFILE_DIRECTORY" value="storage/framework/testing/sip_profiles"/>
     </php>
 </phpunit>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -27,24 +27,24 @@ use App\Http\Controllers\Api\FreeSwitchModuleStatusController;
 use App\Http\Controllers\Api\GatewayController;
 use App\Http\Controllers\Api\HealthController;
 use App\Http\Controllers\Api\HolidayCalendarController;
+use App\Http\Controllers\Api\InteractionController;
+use App\Http\Controllers\Api\IvrController;
 use App\Http\Controllers\Api\MobileDeviceController;
 use App\Http\Controllers\Api\NumberProviderController;
-use App\Http\Controllers\Api\IvrController;
-use App\Http\Controllers\Api\InteractionController;
 use App\Http\Controllers\Api\OfficeFeatureController;
-use App\Http\Controllers\Api\QueueController;
-use App\Http\Controllers\Api\QueueMetricsController;
-use App\Http\Controllers\Api\RecordingController;
-use App\Http\Controllers\Api\RegistrationStatusController;
-use App\Http\Controllers\Api\ScheduleController;
-use App\Http\Controllers\Api\SystemMediaController;
-use App\Http\Controllers\Api\SupervisorReportController;
-use App\Http\Controllers\Api\TeamController;
 use App\Http\Controllers\Api\OrganizationController;
 use App\Http\Controllers\Api\OrganizationDomainSuggestionController;
 use App\Http\Controllers\Api\OrganizationProvisioningHealthController;
 use App\Http\Controllers\Api\OrganizationStatsController;
 use App\Http\Controllers\Api\PlatformSettingController;
+use App\Http\Controllers\Api\QueueController;
+use App\Http\Controllers\Api\QueueMetricsController;
+use App\Http\Controllers\Api\RecordingController;
+use App\Http\Controllers\Api\RegistrationStatusController;
+use App\Http\Controllers\Api\ScheduleController;
+use App\Http\Controllers\Api\SupervisorReportController;
+use App\Http\Controllers\Api\SystemMediaController;
+use App\Http\Controllers\Api\TeamController;
 use App\Http\Controllers\Api\TimeConditionController;
 use App\Http\Controllers\Api\TokenController;
 use App\Http\Controllers\Api\UsageController;
@@ -100,8 +100,13 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     Route::get('permissions', [UserController::class, 'availablePermissions'])->name('permissions.index');
 
     // FreeSWITCH Security & Configuration (Superadmin)
-    Route::apiResource('admin/gateways', \App\Http\Controllers\Api\Admin\AdminGatewayController::class);
-    Route::apiResource('admin/sip-profiles', \App\Http\Controllers\Api\SipProfileController::class);
+    // Gated in middleware, not just in the controllers: middleware runs before
+    // FormRequest validation, so an unauthorized caller gets 403 rather than a
+    // 422 that would let them probe rules like exists:organizations,id.
+    Route::apiResource('admin/gateways', \App\Http\Controllers\Api\Admin\AdminGatewayController::class)
+        ->middleware('can:platform-admin');
+    Route::apiResource('admin/sip-profiles', \App\Http\Controllers\Api\SipProfileController::class)
+        ->middleware('can:platform-admin');
 
     // Platform Admin Log Viewer
     Route::prefix('admin/logs')->name('admin.logs.')->group(function () {

--- a/backend/tests/Feature/Api/AuditLogApiTest.php
+++ b/backend/tests/Feature/Api/AuditLogApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use App\Models\AuditLog;
 use App\Models\Extension;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -53,7 +54,12 @@ class AuditLogApiTest extends TestCase
         $response->assertJsonFragment(['action' => 'created']);
     }
 
-    public function test_user_can_list_audit_logs_default_open(): void
+    /**
+     * Permissions are deny-by-default. An agent holding no explicit grant must
+     * not be able to read the organization's audit trail — this previously
+     * returned 200 because a user with zero grants was allowed everything.
+     */
+    public function test_agent_without_permission_cannot_list_audit_logs(): void
     {
         AuditLog::create([
             'organization_id' => $this->organization->id,
@@ -63,10 +69,27 @@ class AuditLogApiTest extends TestCase
             'auditable_id' => 'test-id',
         ]);
 
-        $response = $this->actingAs($this->user, 'sanctum')
-            ->getJson("/api/v1/organizations/{$this->organization->id}/audit-logs");
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/audit-logs")
+            ->assertForbidden();
+    }
 
-        $response->assertStatus(200);
+    public function test_agent_with_granted_permission_can_list_audit_logs(): void
+    {
+        AuditLog::create([
+            'organization_id' => $this->organization->id,
+            'user_id' => $this->admin->id,
+            'action' => 'updated',
+            'auditable_type' => Extension::class,
+            'auditable_id' => 'test-id',
+        ]);
+
+        Permission::updateOrCreate(['slug' => 'audit_logs.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['audit_logs.view']);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/audit-logs")
+            ->assertStatus(200);
     }
 
     public function test_can_filter_audit_logs_by_action(): void

--- a/backend/tests/Feature/Api/CallControlTenantScopingTest.php
+++ b/backend/tests/Feature/Api/CallControlTenantScopingTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Api;
 
+use App\Models\CallDeliveryAttempt;
 use App\Models\CallSession;
+use App\Models\EndpointBinding;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\EslConnectionManager;
@@ -29,6 +31,81 @@ class CallControlTenantScopingTest extends TestCase
     private function admin(Organization $organization): User
     {
         return User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+    }
+
+    /**
+     * Bind an ESL manager that permits nothing, so any dispatched FreeSWITCH
+     * command is an immediate, explicit test failure.
+     */
+    private function expectNoEslActivity(): void
+    {
+        $esl = Mockery::mock(EslConnectionManager::class);
+        $esl->shouldNotReceive('connect');
+        $esl->shouldNotReceive('api');
+        $esl->shouldNotReceive('bgapi');
+        $this->app->instance(EslConnectionManager::class, $esl);
+    }
+
+    public function test_status_attributes_channels_by_presence_id_domain_suffix(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+
+        $esl = Mockery::mock(EslConnectionManager::class);
+        $esl->shouldReceive('connect')->once()->andReturn(true);
+        $esl->shouldReceive('disconnect')->once();
+        $esl->shouldReceive('api')->once()->andReturn(json_encode([
+            'row_count' => 3,
+            'rows' => [
+                // No session, non-matching context — attributable only by presence.
+                ['uuid' => 'by-presence', 'context' => 'public', 'presence_id' => '1001@mine.test'],
+                // Near miss: the domain must match at the '@' boundary, not as a
+                // bare string suffix, or a lookalike tenant would leak through.
+                ['uuid' => 'lookalike', 'context' => 'public', 'presence_id' => '1001@evil-mine.test'],
+                ['uuid' => 'unrelated', 'context' => 'public', 'presence_id' => '1001@other.test'],
+            ],
+        ]));
+        $this->app->instance(EslConnectionManager::class, $esl);
+
+        $this->actingAs($this->admin($mine), 'sanctum')
+            ->getJson("/api/v1/organizations/{$mine->id}/calls/status")
+            ->assertOk()
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('channels.0.uuid', 'by-presence');
+    }
+
+    public function test_control_accepts_a_delivery_leg_uuid_owned_by_this_organization(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+        $session = CallSession::factory()->create([
+            'organization_id' => $mine->id,
+            'call_uuid' => 'a-leg-uuid',
+        ]);
+
+        // A call delivered to a SIP or PSTN endpoint is controlled through the
+        // B-leg channel UUID, which the API exposes as winner.leg_uuid.
+        $binding = EndpointBinding::factory()->create([
+            'organization_id' => $mine->id,
+            'extension_id' => null,
+        ]);
+        CallDeliveryAttempt::factory()->create([
+            'call_session_id' => $session->id,
+            'endpoint_binding_id' => $binding->id,
+            'freeswitch_leg_uuid' => 'b-leg-uuid',
+        ]);
+
+        $starter = Mockery::mock(AnsweredRecordingStarter::class);
+        $starter->shouldReceive('startForCall')
+            ->once()
+            ->with($mine->id, 'b-leg-uuid')
+            ->andReturn(['status' => 'started', 'path' => '/tmp/x.wav', 'response' => []]);
+        $this->app->instance(AnsweredRecordingStarter::class, $starter);
+
+        $this->actingAs($this->admin($mine), 'sanctum')
+            ->postJson("/api/v1/organizations/{$mine->id}/calls/recording", [
+                'uuid' => 'b-leg-uuid',
+                'action' => 'start',
+            ])
+            ->assertOk();
     }
 
     public function test_status_omits_channels_belonging_to_another_organization(): void
@@ -95,8 +172,10 @@ class CallControlTenantScopingTest extends TestCase
         $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
         CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
 
-        // No ESL binding is registered: a leaked command would fail loudly
-        // rather than silently pass this test.
+        // Strict mock: if the ownership guard regresses, the leaked FreeSWITCH
+        // command fails the test explicitly instead of quietly returning 503.
+        $this->expectNoEslActivity();
+
         $this->actingAs($this->admin($mine), 'sanctum')
             ->postJson("/api/v1/organizations/{$mine->id}/calls/hangup", ['uuid' => 'theirs-uuid'])
             ->assertNotFound();
@@ -108,6 +187,7 @@ class CallControlTenantScopingTest extends TestCase
         $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
         CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
         $actor = $this->admin($mine);
+        $this->expectNoEslActivity();
 
         $this->actingAs($actor, 'sanctum')
             ->postJson("/api/v1/organizations/{$mine->id}/calls/transfer", [

--- a/backend/tests/Feature/Api/CallControlTenantScopingTest.php
+++ b/backend/tests/Feature/Api/CallControlTenantScopingTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\CallSession;
+use App\Models\Organization;
+use App\Models\User;
+use App\Services\EslConnectionManager;
+use App\Services\Recording\AnsweredRecordingStarter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * FreeSWITCH is shared by every tenant, so `show channels` and the uuid_*
+ * commands operate on the whole switch. These tests pin the organization
+ * scoping that keeps one tenant from reading or controlling another's calls.
+ */
+class CallControlTenantScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function admin(Organization $organization): User
+    {
+        return User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+    }
+
+    public function test_status_omits_channels_belonging_to_another_organization(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+        $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
+
+        CallSession::factory()->create(['organization_id' => $mine->id, 'call_uuid' => 'mine-uuid']);
+        CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
+
+        $esl = Mockery::mock(EslConnectionManager::class);
+        $esl->shouldReceive('connect')->once()->andReturn(true);
+        $esl->shouldReceive('disconnect')->once();
+        $esl->shouldReceive('api')->once()->with('show channels as json')->andReturn(json_encode([
+            'row_count' => 3,
+            'rows' => [
+                ['uuid' => 'mine-uuid', 'context' => 'mine.test', 'cid_num' => '1001'],
+                ['uuid' => 'theirs-uuid', 'context' => 'theirs.test', 'cid_num' => '2002'],
+                ['uuid' => 'unattributable-uuid', 'context' => 'public', 'cid_num' => '3003'],
+            ],
+        ]));
+
+        $this->app->instance(EslConnectionManager::class, $esl);
+
+        $response = $this->actingAs($this->admin($mine), 'sanctum')
+            ->getJson("/api/v1/organizations/{$mine->id}/calls/status");
+
+        $response->assertOk()
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('channels.0.uuid', 'mine-uuid');
+
+        $body = $response->json();
+        $this->assertStringNotContainsString('theirs-uuid', json_encode($body));
+        $this->assertStringNotContainsString('2002', json_encode($body));
+    }
+
+    public function test_status_includes_channels_matched_by_organization_domain_context(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+
+        $esl = Mockery::mock(EslConnectionManager::class);
+        $esl->shouldReceive('connect')->once()->andReturn(true);
+        $esl->shouldReceive('disconnect')->once();
+        $esl->shouldReceive('api')->once()->andReturn(json_encode([
+            'row_count' => 2,
+            'rows' => [
+                ['uuid' => 'no-session-yet', 'context' => 'mine.test'],
+                ['uuid' => 'other-tenant', 'context' => 'elsewhere.test'],
+            ],
+        ]));
+
+        $this->app->instance(EslConnectionManager::class, $esl);
+
+        $this->actingAs($this->admin($mine), 'sanctum')
+            ->getJson("/api/v1/organizations/{$mine->id}/calls/status")
+            ->assertOk()
+            ->assertJsonPath('count', 1)
+            ->assertJsonPath('channels.0.uuid', 'no-session-yet');
+    }
+
+    public function test_hangup_refuses_a_uuid_owned_by_another_organization(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+        $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
+        CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
+
+        // No ESL binding is registered: a leaked command would fail loudly
+        // rather than silently pass this test.
+        $this->actingAs($this->admin($mine), 'sanctum')
+            ->postJson("/api/v1/organizations/{$mine->id}/calls/hangup", ['uuid' => 'theirs-uuid'])
+            ->assertNotFound();
+    }
+
+    public function test_transfer_and_hold_refuse_a_foreign_uuid(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+        $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
+        CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
+        $actor = $this->admin($mine);
+
+        $this->actingAs($actor, 'sanctum')
+            ->postJson("/api/v1/organizations/{$mine->id}/calls/transfer", [
+                'uuid' => 'theirs-uuid',
+                'destination' => '1001',
+            ])
+            ->assertNotFound();
+
+        $this->actingAs($actor, 'sanctum')
+            ->postJson("/api/v1/organizations/{$mine->id}/calls/hold", [
+                'uuid' => 'theirs-uuid',
+                'action' => 'hold',
+            ])
+            ->assertNotFound();
+    }
+
+    public function test_recording_toggle_refuses_a_foreign_uuid(): void
+    {
+        $mine = Organization::factory()->create(['domain' => 'mine.test']);
+        $theirs = Organization::factory()->create(['domain' => 'theirs.test']);
+        CallSession::factory()->create(['organization_id' => $theirs->id, 'call_uuid' => 'theirs-uuid']);
+
+        $starter = Mockery::mock(AnsweredRecordingStarter::class);
+        $starter->shouldNotReceive('startForCall');
+        $this->app->instance(AnsweredRecordingStarter::class, $starter);
+
+        $this->actingAs($this->admin($mine), 'sanctum')
+            ->postJson("/api/v1/organizations/{$mine->id}/calls/recording", [
+                'uuid' => 'theirs-uuid',
+                'action' => 'start',
+            ])
+            ->assertNotFound();
+    }
+}

--- a/backend/tests/Feature/Api/CallControllerRecordingTest.php
+++ b/backend/tests/Feature/Api/CallControllerRecordingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api;
 
+use App\Models\CallSession;
 use App\Models\Organization;
 use App\Models\User;
 use App\Services\Recording\AnsweredRecordingStarter;
@@ -23,6 +24,12 @@ class CallControllerRecordingTest extends TestCase
     {
         $organization = Organization::factory()->create(['domain' => 'acme.test']);
         $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'admin']);
+        // Call control verifies the channel belongs to this organization, so the
+        // session has to exist for the command to be dispatched at all.
+        CallSession::factory()->create([
+            'organization_id' => $organization->id,
+            'call_uuid' => 'call-uuid',
+        ]);
 
         $starter = Mockery::mock(AnsweredRecordingStarter::class);
         $starter->shouldReceive('startForCall')
@@ -50,6 +57,12 @@ class CallControllerRecordingTest extends TestCase
     {
         $organization = Organization::factory()->create(['domain' => 'acme.test']);
         $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'admin']);
+        // Call control verifies the channel belongs to this organization, so the
+        // session has to exist for the command to be dispatched at all.
+        CallSession::factory()->create([
+            'organization_id' => $organization->id,
+            'call_uuid' => 'call-uuid',
+        ]);
 
         $starter = Mockery::mock(AnsweredRecordingStarter::class);
         $starter->shouldReceive('stopForCall')

--- a/backend/tests/Feature/Api/ExtensionDeviceLinkPersistenceTest.php
+++ b/backend/tests/Feature/Api/ExtensionDeviceLinkPersistenceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\DeviceProfile;
+use App\Models\Extension;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A desk phone assigned from the Devices page must survive unrelated edits to
+ * the extension it is assigned to.
+ *
+ * ExtensionController::syncOwnedDevice() previously treated an absent
+ * device_profile_id as an instruction to clear the link, so saving a user-owned
+ * extension for any reason — voicemail PIN, caller-ID allow-list, is_active —
+ * silently unlinked the hardware and it stopped provisioning.
+ */
+class ExtensionDeviceLinkPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function admin(Organization $organization): User
+    {
+        return User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+    }
+
+    /**
+     * The update endpoint is a full replace — extension, password, first_name
+     * and last_name are all required — so a realistic "unrelated edit" resends
+     * every field, which is exactly why the reverse-link bug was reachable.
+     *
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function fullPayload(Extension $extension, array $overrides = []): array
+    {
+        return array_merge([
+            'extension' => $extension->extension,
+            'password' => 'sup3r-secret-pass',
+            'first_name' => 'Ayesha',
+            'last_name' => 'Rahman',
+        ], $overrides);
+    }
+
+    public function test_device_link_survives_an_unrelated_extension_update(): void
+    {
+        $organization = Organization::factory()->create();
+        $owner = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        $extension = Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'user_id' => $owner->id,
+            'device_profile_id' => null,
+            'is_active' => true,
+        ]);
+
+        // Assigned from the device side, which is the only way to give a
+        // user-owned extension a physical phone.
+        $device = DeviceProfile::factory()->create([
+            'organization_id' => $organization->id,
+            'extension_id' => $extension->id,
+        ]);
+
+        $this->actingAs($this->admin($organization), 'sanctum')
+            ->putJson(
+                "/api/v1/organizations/{$organization->id}/extensions/{$extension->id}",
+                // Mirrors the admin form, which always submits device_profile_id
+                // as null for a user-owned extension.
+                $this->fullPayload($extension, ['first_name' => 'Renamed', 'device_profile_id' => null]),
+            )
+            ->assertOk();
+
+        $this->assertSame(
+            $extension->id,
+            $device->fresh()->extension_id,
+            'An unrelated extension update must not unlink the assigned device.',
+        );
+    }
+
+    public function test_explicitly_clearing_the_device_still_unlinks_it(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $extension = Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'user_id' => null,
+            'is_active' => true,
+        ]);
+
+        $device = DeviceProfile::factory()->create([
+            'organization_id' => $organization->id,
+            'extension_id' => $extension->id,
+        ]);
+
+        $extension->update(['device_profile_id' => $device->id]);
+
+        $this->actingAs($this->admin($organization), 'sanctum')
+            ->putJson(
+                "/api/v1/organizations/{$organization->id}/extensions/{$extension->id}",
+                $this->fullPayload($extension, ['device_profile_id' => null]),
+            )
+            ->assertOk();
+
+        $this->assertNull(
+            $device->fresh()->extension_id,
+            'Explicitly sending a null device_profile_id must still clear the link.',
+        );
+    }
+
+    public function test_assigning_a_device_from_the_extension_side_still_links_it(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $extension = Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'user_id' => null,
+            'device_profile_id' => null,
+            'is_active' => true,
+        ]);
+
+        $device = DeviceProfile::factory()->create([
+            'organization_id' => $organization->id,
+            'extension_id' => null,
+        ]);
+
+        $this->actingAs($this->admin($organization), 'sanctum')
+            ->putJson(
+                "/api/v1/organizations/{$organization->id}/extensions/{$extension->id}",
+                $this->fullPayload($extension, ['device_profile_id' => $device->id]),
+            )
+            ->assertOk();
+
+        $this->assertSame($extension->id, $device->fresh()->extension_id);
+    }
+}

--- a/backend/tests/Feature/Api/OutboundCallerIdIntegrityTest.php
+++ b/backend/tests/Feature/Api/OutboundCallerIdIntegrityTest.php
@@ -103,8 +103,9 @@ class OutboundCallerIdIntegrityTest extends TestCase
             ])
             ->assertOk();
 
+        // Assert the actual values, not just the parameter keys: the number must
+        // be the allowed DID and the name the extension's configured one.
         $this->assertStringContainsString('origination_caller_id_name=Sales Desk', $captured);
-        $this->assertStringContainsString('origination_caller_id_number=', $captured);
-        $this->assertStringNotContainsString('IRS', $captured);
+        $this->assertStringContainsString('origination_caller_id_number='.($did->normalized_number ?? $did->number), $captured);
     }
 }

--- a/backend/tests/Feature/Api/OutboundCallerIdIntegrityTest.php
+++ b/backend/tests/Feature/Api/OutboundCallerIdIntegrityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Did;
+use App\Models\Extension;
+use App\Models\Organization;
+use App\Models\User;
+use App\Services\EslConnectionManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Both halves of the presented caller ID must be derived server-side.
+ *
+ * The number was already constrained to the extension's allowed outbound DIDs,
+ * but the display name used to be accepted verbatim from the client — which let
+ * any caller who could originate present an arbitrary identity on the PSTN and
+ * defeated the point of the allow-list.
+ */
+class OutboundCallerIdIntegrityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_client_supplied_caller_id_name_is_rejected(): void
+    {
+        $organization = Organization::factory()->create(['domain' => 'acme.test']);
+        $user = User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+        Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'extension' => '1001',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user, 'sanctum')
+            ->postJson("/api/v1/organizations/{$organization->id}/calls/originate", [
+                'extension' => '1001',
+                'destination' => '+15550001111',
+                'caller_id_name' => 'IRS',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('caller_id_name');
+    }
+
+    public function test_caller_id_number_remains_rejected(): void
+    {
+        $organization = Organization::factory()->create(['domain' => 'acme.test']);
+        $user = User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+        Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'extension' => '1001',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($user, 'sanctum')
+            ->postJson("/api/v1/organizations/{$organization->id}/calls/originate", [
+                'extension' => '1001',
+                'destination' => '+15550001111',
+                'caller_id_number' => '+15559998888',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('caller_id_number');
+    }
+
+    public function test_originate_presents_the_extension_configured_name_and_allowed_did(): void
+    {
+        $organization = Organization::factory()->create(['domain' => 'acme.test']);
+        $user = User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+
+        $did = Did::factory()->create([
+            'organization_id' => $organization->id,
+            'number' => '+15550100',
+            'is_active' => true,
+        ]);
+
+        $extension = Extension::factory()->create([
+            'organization_id' => $organization->id,
+            'extension' => '1001',
+            'effective_caller_id_name' => 'Sales Desk',
+            'default_outbound_did_id' => $did->id,
+            'is_active' => true,
+        ]);
+        $extension->allowedOutboundDids()->sync([$did->id]);
+
+        $captured = null;
+        $esl = Mockery::mock(EslConnectionManager::class);
+        $esl->shouldReceive('connect')->once()->andReturn(true);
+        $esl->shouldReceive('disconnect')->once();
+        $esl->shouldReceive('bgapi')->once()->with(Mockery::capture($captured))->andReturn('+OK');
+        $this->app->instance(EslConnectionManager::class, $esl);
+
+        $this->actingAs($user, 'sanctum')
+            ->postJson("/api/v1/organizations/{$organization->id}/calls/originate", [
+                'extension' => '1001',
+                'destination' => '+15550001111',
+            ])
+            ->assertOk();
+
+        $this->assertStringContainsString('origination_caller_id_name=Sales Desk', $captured);
+        $this->assertStringContainsString('origination_caller_id_number=', $captured);
+        $this->assertStringNotContainsString('IRS', $captured);
+    }
+}

--- a/backend/tests/Feature/Api/PlatformAuthorizationTest.php
+++ b/backend/tests/Feature/Api/PlatformAuthorizationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Gateway;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\SipProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Guards the platform-level routes that cross organization boundaries.
+ *
+ * SIP profiles are global FreeSWITCH objects and admin/gateways deliberately
+ * lists every tenant, so both must be reachable only by platform admins.
+ */
+class PlatformAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function platformAdmin(): User
+    {
+        return User::factory()->create(['role' => 'superadmin', 'organization_id' => null]);
+    }
+
+    private function tenantAdmin(Organization $organization): User
+    {
+        return User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+    }
+
+    private function tenantAgent(Organization $organization): User
+    {
+        return User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+    }
+
+    public function test_tenant_admin_cannot_read_sip_profiles(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $this->actingAs($this->tenantAdmin($organization), 'sanctum')
+            ->getJson('/api/v1/admin/sip-profiles')
+            ->assertForbidden();
+    }
+
+    public function test_tenant_agent_cannot_read_sip_profiles(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $this->actingAs($this->tenantAgent($organization), 'sanctum')
+            ->getJson('/api/v1/admin/sip-profiles')
+            ->assertForbidden();
+    }
+
+    public function test_tenant_admin_cannot_create_sip_profile(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $this->actingAs($this->tenantAdmin($organization), 'sanctum')
+            ->postJson('/api/v1/admin/sip-profiles', ['name' => 'malicious'])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('sip_profiles', ['name' => 'malicious']);
+    }
+
+    public function test_tenant_admin_cannot_update_or_delete_sip_profile(): void
+    {
+        $organization = Organization::factory()->create();
+        $profile = SipProfile::create(['name' => 'internal', 'is_active' => true]);
+        $actor = $this->tenantAdmin($organization);
+
+        $this->actingAs($actor, 'sanctum')
+            ->putJson("/api/v1/admin/sip-profiles/{$profile->id}", ['name' => 'hijacked'])
+            ->assertForbidden();
+
+        $this->actingAs($actor, 'sanctum')
+            ->getJson("/api/v1/admin/sip-profiles/{$profile->id}")
+            ->assertForbidden();
+
+        $this->actingAs($actor, 'sanctum')
+            ->deleteJson("/api/v1/admin/sip-profiles/{$profile->id}")
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('sip_profiles', ['id' => $profile->id, 'name' => 'internal']);
+    }
+
+    public function test_platform_admin_can_read_sip_profiles(): void
+    {
+        SipProfile::create(['name' => 'internal', 'is_active' => true]);
+
+        $this->actingAs($this->platformAdmin(), 'sanctum')
+            ->getJson('/api/v1/admin/sip-profiles')
+            ->assertOk();
+    }
+
+    public function test_tenant_user_cannot_enumerate_other_organizations_gateways(): void
+    {
+        $mine = Organization::factory()->create();
+        $theirs = Organization::factory()->create();
+        Gateway::factory()->create(['organization_id' => $theirs->id]);
+
+        // Explicitly grant the slug the policy checks, to prove the platform
+        // gate is what denies this rather than a missing permission.
+        $actor = $this->tenantAgent($mine);
+        Permission::updateOrCreate(['slug' => 'gateways.view'], ['module' => 'module']);
+        $actor->grantPermissions(['gateways.view']);
+
+        $this->actingAs($actor, 'sanctum')
+            ->getJson('/api/v1/admin/gateways')
+            ->assertForbidden();
+    }
+
+    public function test_platform_admin_can_list_all_gateways(): void
+    {
+        $organization = Organization::factory()->create();
+        Gateway::factory()->create(['organization_id' => $organization->id]);
+
+        $this->actingAs($this->platformAdmin(), 'sanctum')
+            ->getJson('/api/v1/admin/gateways')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+}

--- a/backend/tests/Feature/Api/PlatformAuthorizationTest.php
+++ b/backend/tests/Feature/Api/PlatformAuthorizationTest.php
@@ -111,6 +111,29 @@ class PlatformAuthorizationTest extends TestCase
             ->assertForbidden();
     }
 
+    /**
+     * Middleware must reject before FormRequest validation runs, otherwise an
+     * unauthorized caller receives 422 and can probe validation rules such as
+     * exists:organizations,id.
+     */
+    public function test_unauthorized_gateway_write_is_rejected_before_validation(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $this->actingAs($this->tenantAdmin($organization), 'sanctum')
+            ->postJson('/api/v1/admin/gateways', [])
+            ->assertForbidden();
+    }
+
+    public function test_unauthorized_sip_profile_write_is_rejected_before_validation(): void
+    {
+        $organization = Organization::factory()->create();
+
+        $this->actingAs($this->tenantAdmin($organization), 'sanctum')
+            ->postJson('/api/v1/admin/sip-profiles', [])
+            ->assertForbidden();
+    }
+
     public function test_platform_admin_can_list_all_gateways(): void
     {
         $organization = Organization::factory()->create();

--- a/backend/tests/Feature/FreeswitchXmlTest.php
+++ b/backend/tests/Feature/FreeswitchXmlTest.php
@@ -4,9 +4,9 @@ namespace Tests\Feature;
 
 use App\Models\CallSession;
 use App\Models\Did;
-use App\Models\SipProfile;
 use App\Models\Organization;
 use App\Models\OrganizationDialplanManifest;
+use App\Models\SipProfile;
 use Database\Seeders\SipProfileSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -300,7 +300,7 @@ class FreeswitchXmlTest extends TestCase
 
         app(\App\Services\SipProfileCompiler::class)->compileAllToDisk();
 
-        $compiledXml = file_get_contents(storage_path('app/freeswitch/sip_profiles/internal.xml'));
+        $compiledXml = file_get_contents(config('telephony.sip_profile_provisioning.directory').'/internal.xml');
 
         $this->assertIsString($compiledXml);
         $this->assertStringNotContainsString('internal/*.xml', $compiledXml);
@@ -313,7 +313,7 @@ class FreeswitchXmlTest extends TestCase
 
         app(\App\Services\SipProfileCompiler::class)->compileAllToDisk();
 
-        $compiledXml = file_get_contents(storage_path('app/freeswitch/sip_profiles/external.xml'));
+        $compiledXml = file_get_contents(config('telephony.sip_profile_provisioning.directory').'/external.xml');
 
         $this->assertIsString($compiledXml);
         $this->assertStringContainsString('<X-PRE-PROCESS cmd="include" data="/usr/local/freeswitch/db/sip_profiles/external/*.xml"/>', $compiledXml);
@@ -567,7 +567,7 @@ class FreeswitchXmlTest extends TestCase
 
         app(\App\Services\SipProfileCompiler::class)->compileAllToDisk();
 
-        $compiledXml = file_get_contents(storage_path('app/freeswitch/sip_profiles/internal.xml'));
+        $compiledXml = file_get_contents(config('telephony.sip_profile_provisioning.directory').'/internal.xml');
 
         $this->assertIsString($compiledXml);
         $this->assertStringContainsString('<profile name="internal">', $compiledXml);

--- a/backend/tests/Feature/RoleBaselineBackfillMigrationTest.php
+++ b/backend/tests/Feature/RoleBaselineBackfillMigrationTest.php
@@ -23,9 +23,26 @@ class RoleBaselineBackfillMigrationTest extends TestCase
         $migration->up();
     }
 
+    /**
+     * The baseline the migration itself grants, duplicated here on purpose.
+     *
+     * The migration snapshots its own list rather than reading
+     * User::ROLE_BASELINE_PERMISSIONS, so this test must pin the same fixed set
+     * — otherwise a future change to the model constant would silently change
+     * what this test asserts about a historical migration.
+     *
+     * @var list<string>
+     */
+    private const MIGRATION_AGENT_BASELINE = [
+        'extensions.view',
+        'calls.originate',
+        'queues.view',
+        'agents.view',
+    ];
+
     private function seedBaselinePermissions(): void
     {
-        foreach (User::baselinePermissionsFor('agent') as $slug) {
+        foreach (self::MIGRATION_AGENT_BASELINE as $slug) {
             Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
         }
 
@@ -43,7 +60,7 @@ class RoleBaselineBackfillMigrationTest extends TestCase
         $this->runBackfill();
 
         $granted = $agent->fresh()->permissions->pluck('slug')->sort()->values()->all();
-        $expected = collect(User::baselinePermissionsFor('agent'))->sort()->values()->all();
+        $expected = collect(self::MIGRATION_AGENT_BASELINE)->sort()->values()->all();
 
         $this->assertSame($expected, $granted);
         $this->assertTrue($agent->fresh()->hasPermission('extensions.view'));

--- a/backend/tests/Feature/RoleBaselineBackfillMigrationTest.php
+++ b/backend/tests/Feature/RoleBaselineBackfillMigrationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The switch to deny-by-default permissions would otherwise strip access from
+ * every pre-existing agent, since they were relying on the default-open
+ * behavior. The backfill migration grants those users their role baseline.
+ */
+class RoleBaselineBackfillMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function runBackfill(): void
+    {
+        $migration = require database_path('migrations/2026_05_09_120000_backfill_role_baseline_permissions.php');
+        $migration->up();
+    }
+
+    private function seedBaselinePermissions(): void
+    {
+        foreach (User::baselinePermissionsFor('agent') as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+
+        Permission::updateOrCreate(['slug' => 'recordings.view'], ['module' => 'core']);
+    }
+
+    public function test_it_grants_the_baseline_to_agents_holding_no_permissions(): void
+    {
+        $organization = Organization::factory()->create();
+        $this->seedBaselinePermissions();
+
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+        $this->assertFalse($agent->hasPermission('extensions.view'));
+
+        $this->runBackfill();
+
+        $granted = $agent->fresh()->permissions->pluck('slug')->sort()->values()->all();
+        $expected = collect(User::baselinePermissionsFor('agent'))->sort()->values()->all();
+
+        $this->assertSame($expected, $granted);
+        $this->assertTrue($agent->fresh()->hasPermission('extensions.view'));
+        $this->assertFalse($agent->fresh()->hasPermission('recordings.view'));
+    }
+
+    public function test_it_leaves_agents_with_existing_grants_untouched(): void
+    {
+        $organization = Organization::factory()->create();
+        $this->seedBaselinePermissions();
+
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+        $agent->grantPermissions(['recordings.view']);
+
+        $this->runBackfill();
+
+        $this->assertSame(
+            ['recordings.view'],
+            $agent->fresh()->permissions->pluck('slug')->all(),
+            'An explicit permission set was already authoritative and must not be widened.',
+        );
+    }
+
+    public function test_it_is_idempotent(): void
+    {
+        $organization = Organization::factory()->create();
+        $this->seedBaselinePermissions();
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        $this->runBackfill();
+        $afterFirst = $agent->fresh()->permissions->pluck('slug')->sort()->values()->all();
+
+        $this->runBackfill();
+        $afterSecond = $agent->fresh()->permissions->pluck('slug')->sort()->values()->all();
+
+        $this->assertSame($afterFirst, $afterSecond);
+    }
+
+    public function test_it_tolerates_baseline_slugs_that_are_not_installed(): void
+    {
+        $organization = Organization::factory()->create();
+        // Only one baseline slug exists, e.g. modules contributing the others
+        // are disabled in this deployment.
+        Permission::updateOrCreate(['slug' => 'extensions.view'], ['module' => 'core']);
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        $this->runBackfill();
+
+        $this->assertSame(['extensions.view'], $agent->fresh()->permissions->pluck('slug')->all());
+    }
+}

--- a/backend/tests/Unit/Models/PermissionTest.php
+++ b/backend/tests/Unit/Models/PermissionTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Models;
 
-use App\Models\Permission;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -68,7 +68,7 @@ class PermissionTest extends TestCase
         $this->assertTrue($admin->hasPermission('anything.at.all'));
     }
 
-    public function test_user_without_explicit_permissions_defaults_to_allow(): void
+    public function test_user_without_explicit_permissions_is_denied(): void
     {
         $organization = Organization::create([
             'name' => 'Test',
@@ -79,8 +79,10 @@ class PermissionTest extends TestCase
 
         $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
 
-        // Users with no explicit permissions default to allow (pre-sync state)
-        $this->assertTrue($user->hasPermission('extensions.view'));
+        // Permissions are deny-by-default: a user holds exactly what has been
+        // granted. This previously returned true, which meant a new agent
+        // silently held every permission in their organization.
+        $this->assertFalse($user->hasPermission('extensions.view'));
     }
 
     public function test_user_with_granted_permission_returns_true(): void

--- a/backend/tests/Unit/Models/UserPermissionDefaultsTest.php
+++ b/backend/tests/Unit/Models/UserPermissionDefaultsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pins the deny-by-default permission contract.
+ *
+ * hasPermission() was previously default-open: a user with no grants was
+ * allowed everything, so a freshly created agent silently held every
+ * permission in their organization.
+ */
+class UserPermissionDefaultsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_agent_with_no_grants_is_denied(): void
+    {
+        $organization = Organization::factory()->create();
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        $this->assertFalse($agent->hasPermission('recordings.view'));
+        $this->assertFalse($agent->hasPermission('recordings.download'));
+        $this->assertFalse($agent->hasPermission('extensions.update'));
+    }
+
+    public function test_agent_holds_only_explicitly_granted_permissions(): void
+    {
+        $organization = Organization::factory()->create();
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'extensions.view'], ['module' => 'core']);
+        Permission::updateOrCreate(['slug' => 'recordings.view'], ['module' => 'core']);
+        $agent->grantPermissions(['extensions.view']);
+
+        $this->assertTrue($agent->hasPermission('extensions.view'));
+        $this->assertFalse($agent->hasPermission('recordings.view'));
+    }
+
+    public function test_revoking_the_last_permission_does_not_widen_access(): void
+    {
+        $organization = Organization::factory()->create();
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'extensions.view'], ['module' => 'core']);
+        $agent->grantPermissions(['extensions.view']);
+        $agent->revokePermissions(['extensions.view']);
+
+        $this->assertFalse($agent->fresh()->hasPermission('extensions.view'));
+        $this->assertFalse($agent->fresh()->hasPermission('recordings.view'));
+    }
+
+    public function test_admins_and_superadmins_still_bypass_the_check(): void
+    {
+        $organization = Organization::factory()->create();
+        $admin = User::factory()->create(['role' => 'admin', 'organization_id' => $organization->id]);
+        $superadmin = User::factory()->create(['role' => 'superadmin', 'organization_id' => null]);
+
+        $this->assertTrue($admin->hasPermission('recordings.download'));
+        $this->assertTrue($superadmin->hasPermission('recordings.download'));
+    }
+
+    public function test_role_baseline_excludes_other_peoples_sensitive_content(): void
+    {
+        $baseline = User::baselinePermissionsFor('agent');
+
+        $this->assertNotEmpty($baseline);
+
+        foreach (['recordings.view', 'recordings.download', 'recordings.delete', 'cdrs.view', 'cdrs.export', 'audit_logs.view'] as $sensitive) {
+            $this->assertNotContains($sensitive, $baseline, "Agent baseline must not include {$sensitive}");
+        }
+
+        foreach ($baseline as $slug) {
+            $this->assertDoesNotMatchRegularExpression(
+                '/\.(create|update|delete|manage)$/',
+                $slug,
+                "Agent baseline must be read-only, found {$slug}",
+            );
+        }
+    }
+
+    public function test_granting_the_role_baseline_skips_slugs_that_do_not_exist(): void
+    {
+        $organization = Organization::factory()->create();
+        $agent = User::factory()->create(['role' => 'agent', 'organization_id' => $organization->id]);
+
+        // Only one baseline slug exists — e.g. a deployment with the contact
+        // centre module disabled. Granting must not fail on the rest.
+        Permission::updateOrCreate(['slug' => 'extensions.view'], ['module' => 'core']);
+
+        $agent->grantRoleBaselinePermissions();
+
+        $this->assertTrue($agent->fresh()->hasPermission('extensions.view'));
+        $this->assertFalse($agent->fresh()->hasPermission('queues.view'));
+    }
+
+    public function test_admin_role_has_no_baseline_because_it_bypasses_checks(): void
+    {
+        $this->assertSame([], User::baselinePermissionsFor('admin'));
+        $this->assertSame([], User::baselinePermissionsFor('superadmin'));
+        $this->assertSame([], User::baselinePermissionsFor(null));
+    }
+}

--- a/backend/tests/Unit/Policies/PermissionPolicyIntegrationTest.php
+++ b/backend/tests/Unit/Policies/PermissionPolicyIntegrationTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Policies;
 
 use App\Models\Extension;
-use App\Models\Permission;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use App\Policies\ExtensionPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -14,19 +14,20 @@ class PermissionPolicyIntegrationTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_user_with_no_permissions_assigned_defaults_to_allow(): void
+    public function test_user_with_no_permissions_assigned_is_denied(): void
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
         $extension = Extension::factory()->create(['organization_id' => $organization->id]);
         $policy = new ExtensionPolicy;
 
-        // No permissions assigned → default-open
-        $this->assertTrue($policy->viewAny($user));
-        $this->assertTrue($policy->view($user, $extension));
-        $this->assertTrue($policy->create($user));
-        $this->assertTrue($policy->update($user, $extension));
-        $this->assertTrue($policy->delete($user, $extension));
+        // No permissions assigned → denied. Policies are deny-by-default, so an
+        // agent nobody has configured cannot read or mutate extensions.
+        $this->assertFalse($policy->viewAny($user));
+        $this->assertFalse($policy->view($user, $extension));
+        $this->assertFalse($policy->create($user));
+        $this->assertFalse($policy->update($user, $extension));
+        $this->assertFalse($policy->delete($user, $extension));
     }
 
     public function test_user_with_view_only_permission_cannot_create(): void

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -192,13 +192,13 @@ const router = createBrowserRouter(
                 <Route path="capabilities" element={<SuperadminOnlyRoute><CapabilitiesPage /></SuperadminOnlyRoute>} />
                 <Route path="system-settings" element={<SuperadminOnlyRoute><SystemSettingsPage /></SuperadminOnlyRoute>} />
                 <Route path="logs" element={<AuditLogsPage />} />
-                <Route path="system-logs" element={<LogViewerPage />} />
+                <Route path="system-logs" element={<SuperadminOnlyRoute><LogViewerPage /></SuperadminOnlyRoute>} />
                 <Route path="auth-tokens" element={<AuthTokensPage />} />
-                <Route path="sip-status" element={<SipStatusPage />} />
+                <Route path="sip-status" element={<SuperadminOnlyRoute><SipStatusPage /></SuperadminOnlyRoute>} />
                 <Route path="freeswitch/modules" element={<SuperadminOnlyRoute><FreeSwitchModulesPage /></SuperadminOnlyRoute>} />
-                <Route path="sip-profiles" element={<SipProfilesPage />} />
-                <Route path="sip-profiles/create" element={<SipProfileFormPage />} />
-                <Route path="sip-profiles/:id/edit" element={<SipProfileFormPage />} />
+                <Route path="sip-profiles" element={<SuperadminOnlyRoute><SipProfilesPage /></SuperadminOnlyRoute>} />
+                <Route path="sip-profiles/create" element={<SuperadminOnlyRoute><SipProfileFormPage /></SuperadminOnlyRoute>} />
+                <Route path="sip-profiles/:id/edit" element={<SuperadminOnlyRoute><SipProfileFormPage /></SuperadminOnlyRoute>} />
             </Route>
 
             {/* Catch-all */}


### PR DESCRIPTION
Implements the Wave 0 findings from the UX review in #32. Every fix has regression coverage. Companion to #32, which is docs-only.

## 1. Platform objects were reachable by any authenticated user

- **`SipProfileController` had no authorization at all** — no `authorize()`, no gate, and its route sits outside `EnsureOrganizationAccess`. SIP profiles are *global* FreeSWITCH objects, and saving one triggers `sofia profile <name> restart`, dropping registrations for every tenant. All five actions now require `platform-admin`, matching `LogViewerController` / `SipStatusController` / `PlatformSettingController`.
- **`AdminGatewayController`** deliberately crosses tenants (`index` lists everyone, `store` accepts an arbitrary `organization_id`) but was guarded only by `hasPermission('gateways.view')`. Now also requires `platform-admin`. The org-scoped path remains `Api\GatewayController`.
- **Five superadmin routes were enforced in the nav but not the router**: `sip-profiles` + both forms, `system-logs`, `sip-status`.

## 2. Permissions were default-open

`User::hasPermission()` returned `true` for any user with **zero** grants — the default state for a newly created agent (`role => 'agent'`). Permissions subtracted rather than added, so a new agent could list, download, and **delete** every recording in their organization until someone narrowed them.

Now deny-by-default. Because admins short-circuit, only agents are affected. To avoid locking them out:

- New non-admin users get a role baseline at creation.
- A migration backfills existing agents who hold no grants, leaving anyone with explicit grants untouched.
- The baseline is deliberately minimal and read-only — `extensions.view`, `calls.originate`, `queues.view`, `agents.view`. Since **no policy narrows visibility below the organization yet**, every grant is org-wide, so recordings, CDRs, and audit logs are excluded on purpose. A test asserts that. Widen it only alongside own/team scoping.

`AuditLogApiTest` previously asserted the default-open behavior (`test_user_can_list_audit_logs_default_open`); replaced with both the denied and explicitly-granted cases.

## 3. Live call control was not tenant-scoped

- **`calls/status`** ran `show channels as json` and returned every channel on the shared switch — the route's `Organization` argument was never used. Now filtered to channels attributable to the org via `CallSession` or dialplan context, **omitting** unattributable channels rather than leaking them.
- **`hangup` / `transfer` / `hold` / `recording`** took arbitrary channel UUIDs with no ownership check, so naming another tenant's UUID was enough to hang up or start recording their call — and `status()` handed out every UUID on the switch. Each now resolves the UUID through an org-scoped `CallSession` first, 404 otherwise.
- **`CallSessionController` had no authorization at all** (`// Assuming Gate::authorize(...) can be wired later`), so any org member could read everyone's calls. Added `CallSessionPolicy` on `cdrs.view`.

## 4. Outbound caller ID was half-spoofable

`caller_id_name` was accepted as `nullable|string` and passed straight to `origination_caller_id_name`, so anyone who could originate could present an arbitrary display name ("IRS", a colleague's name) on the PSTN — defeating the point of the DID allow-list, which already constrained the *number*. Now `prohibited` and derived server-side, matching how `caller_id_number` was already handled. No existing test supplied a caller-side name, so legitimate behavior is unchanged.

## 5. Data loss on the extension↔device link

`syncOwnedDevice()` cleared `DeviceProfile.extension_id` whenever the extension payload lacked `device_profile_id`. The admin form **always** submits it as `null` for a user-owned extension, so a phone assigned from the Devices page was silently unlinked on any unrelated extension edit — voicemail PIN, caller-ID allow-list, `is_active` — and stopped provisioning. The reverse link is now reconciled only when the extension's own field actually changes.

(My first attempt guarded on `array_key_exists`, which was wrong: the key *is* present. The test reproduces the real UI payload.)

## 6. Test isolation

Saving a `SipProfile` recompiles every profile to disk, which rewrote the **checked-in** `storage/app/freeswitch/sip_profiles/*.xml` and left the working tree dirty after any test run. The output directory is now overridable via `FREESWITCH_SIP_PROFILE_DIRECTORY`, following the existing `FREESWITCH_GATEWAY_DIRECTORY` pattern, with phpunit pointing at `storage/framework/testing`.

## Verification

Docker is unavailable in this environment, so this ran on host PHP 8.4 against the suite's in-memory SQLite. **53 tests / 133 assertions pass** across the new and touched suites.

Pre-existing failures were confirmed **identical against `origin/main`** in a clean worktree, so none are regressions:

| Suite | Status |
|---|---|
| `ExtensionApiTest` | 11 failures, same on `main` |
| `CallOriginateApiTest` | 3 errors + 1 failure, same on `main` |
| `EventProcessorEventLogTest` | 4 failures, same on `main` |
| `WebRtcConfigServiceTest`, `SipStatusControllerTest` | hang without FreeSWITCH, before and after |

Frontend: `npm run build` succeeds; `tsc --noEmit` reports zero errors in `app.tsx` (the 100 pre-existing errors are all in untouched `flow-builder` files). `pint --dirty` clean.

Two things worth a maintainer's eye:

1. **The agent baseline is a product decision.** I picked the most conservative set that leaves an agent able to function. If agents should see call history or their own recordings, that needs the `own`/`team` scoping from §8.2 of the review first — granting it org-wide today would expose colleagues' calls.
2. **Consolidating `admin/*` behind middleware** would be tidier than per-method gates, but it would also catch `admin/dashboard` and `admin/capabilities`, which self-gate differently. I kept the surgical form to avoid changing behavior I hadn't verified; the middleware consolidation is a reasonable follow-up.

Also noticed but **not** fixed here: the committed `.env.testing` ships an invalid placeholder `APP_KEY` (`base64:base64base64...`), so every test touching an encrypted cast fails outside Docker. Worth a separate fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgFhcmCXanomL3MVmkk5UZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Access**
  - Strengthened platform-admin controls for gateway and SIP profile management.
  - Added permission-based access for system logs, call sessions, SIP status, and profiles.
  - New users receive appropriate baseline permissions automatically.

- **Bug Fixes**
  - Prevented cross-organization access to call status and call-control actions.
  - Caller ID information is now protected from client-side manipulation.
  - Preserved device links during unrelated extension updates.

- **Configuration**
  - Added configurable SIP profile provisioning directory support.

- **Tests**
  - Added coverage for authorization, tenant isolation, caller ID integrity, device links, and permission defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->