### PR TITLE
feat(admin): Wave 1 — recordings UI, CDR-backed call history, effective recording policy

### DIFF
--- a/backend/app/Console/Commands/SyncPermissionsCommand.php
+++ b/backend/app/Console/Commands/SyncPermissionsCommand.php
@@ -50,6 +50,14 @@ class SyncPermissionsCommand extends Command
         'device_profiles.create' => 'Create device profiles',
         'device_profiles.update' => 'Update device profiles',
         'device_profiles.delete' => 'Delete device profiles',
+        // EndpointBindingPolicy has always checked these, but nothing declared
+        // them, so sync never created the rows. Under deny-by-default that made
+        // mobile-device and softphone binding management permanently
+        // unreachable for anyone below admin.
+        'endpoint_bindings.view' => 'View endpoint bindings',
+        'endpoint_bindings.create' => 'Create endpoint bindings',
+        'endpoint_bindings.update' => 'Update endpoint bindings',
+        'endpoint_bindings.delete' => 'Delete endpoint bindings',
         'calls.originate' => 'Originate calls',
         'calls.view_status' => 'View active call status',
         'recordings.view' => 'View recordings',

--- a/backend/app/Http/Controllers/Api/CallController.php
+++ b/backend/app/Http/Controllers/Api/CallController.php
@@ -74,12 +74,10 @@ class CallController extends Controller
             return response()->json(['message' => 'Extension not found or inactive.'], 404);
         }
 
-        $esl = app(EslConnectionManager::class);
-
-        if (! $esl->connect()) {
-            return response()->json(['message' => 'Unable to connect to FreeSWITCH.'], 503);
-        }
-
+        // The outbound policy is resolved from stored state, so it is checked
+        // before touching FreeSWITCH. Connecting first meant a request rejected
+        // for policy reasons both required a reachable switch to be rejected at
+        // all and returned without closing the connection it had opened.
         try {
             $originateString = $this->outboundOriginateService->buildCommand(
                 organization: $organization,
@@ -95,6 +93,12 @@ class CallController extends Controller
                     'outbound_policy' => [$exception->getMessage()],
                 ],
             ], 422);
+        }
+
+        $esl = app(EslConnectionManager::class);
+
+        if (! $esl->connect()) {
+            return response()->json(['message' => 'Unable to connect to FreeSWITCH.'], 503);
         }
 
         $response = $esl->bgapi($originateString);

--- a/backend/app/Http/Controllers/Api/CallController.php
+++ b/backend/app/Http/Controllers/Api/CallController.php
@@ -101,8 +101,13 @@ class CallController extends Controller
             return response()->json(['message' => 'Unable to connect to FreeSWITCH.'], 503);
         }
 
-        $response = $esl->bgapi($originateString);
-        $esl->disconnect();
+        try {
+            $response = $esl->bgapi($originateString);
+        } finally {
+            // The connection is closed even if the command throws, so a failed
+            // originate cannot leave a socket open for the life of the worker.
+            $esl->disconnect();
+        }
 
         return response()->json([
             'message' => 'Call originated.',

--- a/backend/app/Http/Controllers/Api/CallDetailRecordController.php
+++ b/backend/app/Http/Controllers/Api/CallDetailRecordController.php
@@ -35,22 +35,34 @@ class CallDetailRecordController extends Controller
 
         $perPage = (int) $request->input('per_page', 25);
 
+        // The summary rides along in `meta` rather than being fetched separately
+        // so the KPI tiles above a filtered table always describe that same
+        // filtered set — the analytics endpoint only understands a date range.
         return CallDetailRecordResource::collection(
             $this->searchService->search($organization, $request, $perPage)
-        );
+        )->additional([
+            'meta' => [
+                'summary' => $this->searchService->summarize($organization, $request),
+            ],
+        ]);
     }
 
     /**
      * Show a single CDR with enrichment data.
      */
-    public function show(Organization $organization, CallDetailRecord $cdr): JsonResponse|CallDetailRecordResource
+    public function show(Request $request, Organization $organization, CallDetailRecord $cdr): JsonResponse|CallDetailRecordResource
     {
-        $this->authorize('view', $cdr);
         if ($cdr->organization_id !== $organization->id) {
             return response()->json(['message' => 'CDR not found.'], 404);
         }
 
-        $cdr->load('enrichment', 'recordings');
+        $this->authorize('view', $cdr);
+
+        $cdr->load('enrichment', 'callSession:id,call_uuid');
+
+        if ($this->searchService->canViewRecordings($request)) {
+            $cdr->load('recordings');
+        }
 
         return new CallDetailRecordResource($cdr);
     }

--- a/backend/app/Http/Controllers/Api/CdrExportController.php
+++ b/backend/app/Http/Controllers/Api/CdrExportController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\CallDetailRecordResource;
 use App\Models\CallDetailRecord;
 use App\Models\Organization;
 use App\Services\Cdr\CdrSearchService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -46,7 +47,7 @@ class CdrExportController extends Controller
 
         $headers = [
             'Content-Type' => 'text/csv; charset=utf-8',
-            'Content-Disposition' => 'attachment; filename="cdrs_export_' . now()->format('Y-m-d_His') . '.csv"',
+            'Content-Disposition' => 'attachment; filename="cdrs_export_'.now()->format('Y-m-d_His').'.csv"',
         ];
 
         $columns = [
@@ -93,52 +94,20 @@ class CdrExportController extends Controller
 
     /**
      * Build the export query with filters applied.
+     *
+     * Filters come from CdrSearchService so an export always covers exactly the
+     * rows the on-screen table shows. This class used to reimplement a subset of
+     * them and quietly dropped the `search` box, producing a CSV of unrelated
+     * calls whenever an operator exported a narrowed view.
      */
-    protected function buildExportQuery(Request $request, Organization $organization)
+    protected function buildExportQuery(Request $request, Organization $organization): Builder
     {
-        $query = CallDetailRecord::where('organization_id', $organization->id)
-            ->with('enrichment')
-            ->orderBy('start_stamp', 'desc');
+        $query = CallDetailRecord::query()
+            ->where('organization_id', $organization->id)
+            ->with('enrichment');
 
-        if ($request->filled('direction')) {
-            $query->where('direction', $request->input('direction'));
-        }
-
-        if ($request->filled('call_type')) {
-            $query->where('call_type', $request->input('call_type'));
-        }
-
-        if ($request->filled('uuid')) {
-            $query->where('uuid', $request->input('uuid'));
-        }
-
-        if ($request->filled('hangup_cause')) {
-            $query->where('hangup_cause', $request->input('hangup_cause'));
-        }
-
-        if ($request->filled('caller_id_number')) {
-            $query->where('caller_id_number', $request->input('caller_id_number'));
-        }
-
-        if ($request->filled('destination_number')) {
-            $query->where('destination_number', $request->input('destination_number'));
-        }
-
-        if ($request->filled('date_from')) {
-            $query->where('start_stamp', '>=', $request->input('date_from'));
-        }
-
-        if ($request->filled('date_to')) {
-            $query->where('start_stamp', '<=', $request->input('date_to'));
-        }
-
-        if ($request->filled('quality_score_min')) {
-            $query->where('quality_score', '>=', (int) $request->input('quality_score_min'));
-        }
-
-        if ($request->filled('mos_score_min')) {
-            $query->where('mos_score', '>=', (float) $request->input('mos_score_min'));
-        }
+        $this->searchService->applyFilters($query, $request);
+        $this->searchService->applySorting($query, $request);
 
         return $query;
     }

--- a/backend/app/Http/Controllers/Api/ExtensionController.php
+++ b/backend/app/Http/Controllers/Api/ExtensionController.php
@@ -15,6 +15,7 @@ use App\Services\OrganizationManifestBuilder;
 use App\Services\WebhookDispatcher;
 use App\Services\WebRtcConfigService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use InvalidArgumentException;
 
 /**
@@ -31,16 +32,22 @@ class ExtensionController extends Controller
 
     /**
      * List extensions for an organization (paginated).
+     *
+     * `per_page` is honoured because callers that need the whole dial plan — the
+     * pickers that resolve an extension number to a name — would otherwise only
+     * ever see the first page and label everything beyond it as unknown.
      */
-    public function index(Organization $organization)
+    public function index(Request $request, Organization $organization)
     {
         $this->authorize('viewAny', Extension::class);
+
+        $perPage = max(1, min((int) $request->input('per_page', 15) ?: 15, 500));
 
         return ExtensionResource::collection(
             $organization->extensions()
                 ->with(['allowedOutboundDids:id', 'allowedOutboundGateways:id'])
                 ->orderBy('extension')
-                ->paginate(15)
+                ->paginate($perPage)
         );
     }
 

--- a/backend/app/Http/Controllers/Api/RecordingController.php
+++ b/backend/app/Http/Controllers/Api/RecordingController.php
@@ -28,31 +28,48 @@ class RecordingController extends Controller
         $query = Recording::where('organization_id', $organization->id)
             ->orderBy('created_at', 'desc');
 
-        if ($request->filled('call_uuid')) {
-            $query->where('call_uuid', $request->input('call_uuid'));
+        if (($value = $this->scalarFilter($request, 'call_uuid')) !== null) {
+            $query->where('call_uuid', $value);
         }
 
         // Numbers match on a substring: an operator searching for a recording
         // types the digits they remember, not the exact stored E.164 string.
-        if ($request->filled('caller_id_number')) {
-            $query->where('caller_id_number', 'LIKE', '%'.$request->input('caller_id_number').'%');
+        foreach (['caller_id_number', 'destination_number'] as $column) {
+            if (($value = $this->scalarFilter($request, $column)) !== null) {
+                $query->where($column, 'LIKE', '%'.$value.'%');
+            }
         }
 
-        if ($request->filled('destination_number')) {
-            $query->where('destination_number', 'LIKE', '%'.$request->input('destination_number').'%');
+        if (($from = $this->scalarFilter($request, 'date_from')) !== null) {
+            $query->where('created_at', '>=', DateRangeFilter::start($from));
         }
 
-        if ($request->filled('date_from')) {
-            $query->where('created_at', '>=', DateRangeFilter::start($request->input('date_from')));
-        }
-
-        if ($request->filled('date_to')) {
-            $query->where('created_at', '<=', DateRangeFilter::end($request->input('date_to')));
+        if (($to = $this->scalarFilter($request, 'date_to')) !== null) {
+            $query->where('created_at', '<=', DateRangeFilter::end($to));
         }
 
         $perPage = max(1, min((int) $request->input('per_page', 15) ?: 15, 100));
 
         return RecordingResource::collection($query->paginate($perPage));
+    }
+
+    /**
+     * A filter value as a string, or null when it is absent or not scalar.
+     *
+     * A query string can carry an array (`?date_to[]=x`); passing one to a date
+     * parser or a query binding raised a TypeError and answered 500.
+     */
+    protected function scalarFilter(Request $request, string $key): ?string
+    {
+        $value = $request->input($key);
+
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $value = (string) $value;
+
+        return $value === '' ? null : $value;
     }
 
     public function show(Organization $organization, Recording $recording): RecordingResource|JsonResponse

--- a/backend/app/Http/Controllers/Api/RecordingController.php
+++ b/backend/app/Http/Controllers/Api/RecordingController.php
@@ -4,9 +4,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\RecordingResource;
-use App\Models\Recording;
 use App\Models\Organization;
+use App\Models\Recording;
 use App\Services\Storage\StorageDriver;
+use App\Support\DateRangeFilter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
@@ -31,23 +32,27 @@ class RecordingController extends Controller
             $query->where('call_uuid', $request->input('call_uuid'));
         }
 
+        // Numbers match on a substring: an operator searching for a recording
+        // types the digits they remember, not the exact stored E.164 string.
         if ($request->filled('caller_id_number')) {
-            $query->where('caller_id_number', $request->input('caller_id_number'));
+            $query->where('caller_id_number', 'LIKE', '%'.$request->input('caller_id_number').'%');
         }
 
         if ($request->filled('destination_number')) {
-            $query->where('destination_number', $request->input('destination_number'));
+            $query->where('destination_number', 'LIKE', '%'.$request->input('destination_number').'%');
         }
 
         if ($request->filled('date_from')) {
-            $query->where('created_at', '>=', $request->input('date_from'));
+            $query->where('created_at', '>=', DateRangeFilter::start($request->input('date_from')));
         }
 
         if ($request->filled('date_to')) {
-            $query->where('created_at', '<=', $request->input('date_to'));
+            $query->where('created_at', '<=', DateRangeFilter::end($request->input('date_to')));
         }
 
-        return RecordingResource::collection($query->paginate(15));
+        $perPage = max(1, min((int) $request->input('per_page', 15) ?: 15, 100));
+
+        return RecordingResource::collection($query->paginate($perPage));
     }
 
     public function show(Organization $organization, Recording $recording): RecordingResource|JsonResponse

--- a/backend/app/Http/Controllers/Api/RecordingPolicyController.php
+++ b/backend/app/Http/Controllers/Api/RecordingPolicyController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Did;
 use App\Models\Extension;
 use App\Models\Organization;
+use App\Services\Recording\RecordingPolicy;
 use App\Services\Recording\RecordingPolicyResolver;
 use Illuminate\Http\JsonResponse;
 
@@ -43,11 +44,13 @@ class RecordingPolicyController extends Controller
      */
     public function did(Organization $organization, Did $did): JsonResponse
     {
-        $this->authorize('view', $did);
-
+        // Scope first: a DID belonging to another organization is absent from
+        // this URL, and answering 403 would confirm that it exists.
         if ($did->organization_id !== $organization->id) {
             return response()->json(['message' => 'DID not found.'], 404);
         }
+
+        $this->authorize('view', $did);
 
         return response()->json([
             'data' => [
@@ -63,30 +66,68 @@ class RecordingPolicyController extends Controller
 
     /**
      * Effective recording policy at extension scope.
-     *
-     * The extension's DID context comes from its default outbound DID, when set.
      */
     public function extension(Organization $organization, Extension $extension): JsonResponse
     {
-        $this->authorize('view', $extension);
-
         if ($extension->organization_id !== $organization->id) {
             return response()->json(['message' => 'Extension not found.'], 404);
         }
 
+        $this->authorize('view', $extension);
+
         $extension->loadMissing('defaultOutboundDid');
+
+        $base = [
+            'extension_policy' => $extension->recording_policy,
+            'organization_policy' => $organization->recording_policy,
+            'answered_target_type' => 'extension',
+        ];
 
         return response()->json([
             'data' => [
                 'scope' => 'extension',
-                ...$this->resolveBothDirections([
-                    'extension_policy' => $extension->recording_policy,
+                // Inbound and outbound resolve through different DID layers.
+                //
+                // Outbound calls carry the extension's default outbound DID, so
+                // that number's policy sits between extension and organization.
+                // Inbound calls arrive on whatever number routed to this
+                // extension, which is not a single value — attributing the
+                // outbound DID to inbound calls reported a policy that would
+                // never apply. Inbound is therefore resolved without a DID
+                // layer, and the numbers that would override it are listed
+                // separately.
+                'inbound' => $this->resolver->resolve([...$base, 'direction' => 'inbound']),
+                'outbound' => $this->resolver->resolve([
+                    ...$base,
                     'did_policy' => $extension->defaultOutboundDid?->recording_policy,
-                    'organization_policy' => $organization->recording_policy,
-                    'answered_target_type' => 'extension',
+                    'direction' => 'outbound',
                 ]),
+                'inbound_did_overrides' => $this->inboundDidOverrides($extension),
             ],
         ]);
+    }
+
+    /**
+     * Numbers routed straight to this extension whose own policy would win over
+     * the extension's for calls arriving on them.
+     *
+     * @return array<int, array{id: string, number: string, recording_policy: string}>
+     */
+    protected function inboundDidOverrides(Extension $extension): array
+    {
+        return Did::query()
+            ->where('organization_id', $extension->organization_id)
+            ->where('destination_type', 'extension')
+            ->where('destination_id', $extension->id)
+            ->get(['id', 'number', 'recording_policy'])
+            ->reject(fn (Did $did) => RecordingPolicy::normalize($did->recording_policy) === RecordingPolicy::INHERIT)
+            ->map(fn (Did $did) => [
+                'id' => (string) $did->id,
+                'number' => (string) $did->number,
+                'recording_policy' => RecordingPolicy::normalize($did->recording_policy),
+            ])
+            ->values()
+            ->all();
     }
 
     /**

--- a/backend/app/Http/Controllers/Api/RecordingPolicyController.php
+++ b/backend/app/Http/Controllers/Api/RecordingPolicyController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Did;
+use App\Models\Extension;
+use App\Models\Organization;
+use App\Services\Recording\RecordingPolicyResolver;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Read-only API for surfacing what the recording policy resolver actually
+ * decides for a given scope, so admins can see the effective outcome
+ * instead of a bare "Inherit" that silently resolves elsewhere.
+ */
+class RecordingPolicyController extends Controller
+{
+    public function __construct(
+        protected RecordingPolicyResolver $resolver,
+    ) {}
+
+    /**
+     * Effective recording policy at organization scope.
+     */
+    public function organization(Organization $organization): JsonResponse
+    {
+        $this->authorize('view', $organization);
+
+        return response()->json([
+            'data' => [
+                'scope' => 'organization',
+                ...$this->resolveBothDirections([
+                    'organization_policy' => $organization->recording_policy,
+                    'answered_target_type' => 'organization',
+                ]),
+            ],
+        ]);
+    }
+
+    /**
+     * Effective recording policy at DID scope.
+     */
+    public function did(Organization $organization, Did $did): JsonResponse
+    {
+        $this->authorize('view', $did);
+
+        if ($did->organization_id !== $organization->id) {
+            return response()->json(['message' => 'DID not found.'], 404);
+        }
+
+        return response()->json([
+            'data' => [
+                'scope' => 'did',
+                ...$this->resolveBothDirections([
+                    'did_policy' => $did->recording_policy,
+                    'organization_policy' => $organization->recording_policy,
+                    'answered_target_type' => 'did',
+                ]),
+            ],
+        ]);
+    }
+
+    /**
+     * Effective recording policy at extension scope.
+     *
+     * The extension's DID context comes from its default outbound DID, when set.
+     */
+    public function extension(Organization $organization, Extension $extension): JsonResponse
+    {
+        $this->authorize('view', $extension);
+
+        if ($extension->organization_id !== $organization->id) {
+            return response()->json(['message' => 'Extension not found.'], 404);
+        }
+
+        $extension->loadMissing('defaultOutboundDid');
+
+        return response()->json([
+            'data' => [
+                'scope' => 'extension',
+                ...$this->resolveBothDirections([
+                    'extension_policy' => $extension->recording_policy,
+                    'did_policy' => $extension->defaultOutboundDid?->recording_policy,
+                    'organization_policy' => $organization->recording_policy,
+                    'answered_target_type' => 'extension',
+                ]),
+            ],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array{inbound: array<string, mixed>, outbound: array<string, mixed>}
+     */
+    protected function resolveBothDirections(array $context): array
+    {
+        return [
+            'inbound' => $this->resolver->resolve([...$context, 'direction' => 'inbound']),
+            'outbound' => $this->resolver->resolve([...$context, 'direction' => 'outbound']),
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StoreOrganizationRequest.php
+++ b/backend/app/Http/Requests/StoreOrganizationRequest.php
@@ -42,6 +42,7 @@ class StoreOrganizationRequest extends FormRequest
             'is_active' => 'boolean',
             'status' => ['string', Rule::in(Organization::VALID_STATUSES)],
             'recording_policy' => ['string', Rule::in(['inherit', 'off', 'all', 'incoming', 'outgoing'])],
+            'recording_retention_days' => 'nullable|integer|min:0',
         ];
     }
 

--- a/backend/app/Http/Requests/UpdateOrganizationRequest.php
+++ b/backend/app/Http/Requests/UpdateOrganizationRequest.php
@@ -44,6 +44,7 @@ class UpdateOrganizationRequest extends FormRequest
             'is_active' => 'boolean',
             'status' => ['string', Rule::in(Organization::VALID_STATUSES)],
             'recording_policy' => ['string', Rule::in(['inherit', 'off', 'all', 'incoming', 'outgoing'])],
+            'recording_retention_days' => 'nullable|integer|min:0',
         ];
     }
 

--- a/backend/app/Http/Resources/CallDetailRecordResource.php
+++ b/backend/app/Http/Resources/CallDetailRecordResource.php
@@ -10,6 +10,8 @@ class CallDetailRecordResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
+        $mayViewRecordings = $request->user()?->can('viewAny', Recording::class) ?? false;
+
         return [
             'id' => $this->id,
             'organization_id' => $this->organization_id,
@@ -28,10 +30,7 @@ class CallDetailRecordResource extends JsonResource
             'call_type' => $this->call_type,
             // The raw storage path is only useful to an operator who may access
             // the audio anyway, so it follows the recordings permission.
-            'recording_path' => $this->when(
-                $request->user()?->can('viewAny', Recording::class) ?? false,
-                fn () => $this->recording_path
-            ),
+            'recording_path' => $this->when($mayViewRecordings, fn () => $this->recording_path),
             'sip_user_agent' => $this->sip_user_agent,
             'remote_media_ip' => $this->remote_media_ip,
             'quality' => [
@@ -53,7 +52,9 @@ class CallDetailRecordResource extends JsonResource
             // Shaped through RecordingResource rather than dumped raw, so the
             // client gets a stable contract and no internal file paths.
             'recordings' => RecordingResource::collection($this->whenLoaded('recordings')),
-            'has_recording' => $this->resolveHasRecording(),
+            // Whether audio exists is itself recording metadata, so it follows
+            // the same permission rather than leaking through a boolean.
+            'has_recording' => $this->when($mayViewRecordings, fn () => $this->resolveHasRecording()),
             // Present only when the call was traced through the delivery
             // pipeline; lets call history link to the interaction journey.
             'call_session_id' => $this->whenLoaded('callSession', fn () => $this->callSession?->id),

--- a/backend/app/Http/Resources/CallDetailRecordResource.php
+++ b/backend/app/Http/Resources/CallDetailRecordResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Recording;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -25,7 +26,12 @@ class CallDetailRecordResource extends JsonResource
             'hangup_cause' => $this->hangup_cause,
             'direction' => $this->direction,
             'call_type' => $this->call_type,
-            'recording_path' => $this->recording_path,
+            // The raw storage path is only useful to an operator who may access
+            // the audio anyway, so it follows the recordings permission.
+            'recording_path' => $this->when(
+                $request->user()?->can('viewAny', Recording::class) ?? false,
+                fn () => $this->recording_path
+            ),
             'sip_user_agent' => $this->sip_user_agent,
             'remote_media_ip' => $this->remote_media_ip,
             'quality' => [

--- a/backend/app/Http/Resources/CallDetailRecordResource.php
+++ b/backend/app/Http/Resources/CallDetailRecordResource.php
@@ -44,9 +44,31 @@ class CallDetailRecordResource extends JsonResource
                 'number_type' => $this->enrichment->number_type,
                 'enriched_at' => $this->enrichment->enriched_at,
             ]),
-            'recordings' => $this->whenLoaded('recordings'),
+            // Shaped through RecordingResource rather than dumped raw, so the
+            // client gets a stable contract and no internal file paths.
+            'recordings' => RecordingResource::collection($this->whenLoaded('recordings')),
+            'has_recording' => $this->resolveHasRecording(),
+            // Present only when the call was traced through the delivery
+            // pipeline; lets call history link to the interaction journey.
+            'call_session_id' => $this->whenLoaded('callSession', fn () => $this->callSession?->id),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];
+    }
+
+    /**
+     * Whether audio exists for this call.
+     *
+     * Prefers loaded Recording rows, falling back to the recording_path column
+     * FreeSWITCH writes — a call can have a path before the file is ingested as
+     * a Recording row, and the UI should still indicate audio is expected.
+     */
+    private function resolveHasRecording(): bool
+    {
+        if ($this->relationLoaded('recordings')) {
+            return $this->recordings->isNotEmpty() || filled($this->recording_path);
+        }
+
+        return filled($this->recording_path);
     }
 }

--- a/backend/app/Http/Resources/OrganizationResource.php
+++ b/backend/app/Http/Resources/OrganizationResource.php
@@ -31,6 +31,7 @@ class OrganizationResource extends JsonResource
             'settings' => $this->settings,
             'status' => $this->status,
             'recording_policy' => $this->recording_policy,
+            'recording_retention_days' => $this->recording_retention_days,
             'max_extensions' => $this->max_extensions,
             'max_concurrent_calls' => $this->max_concurrent_calls,
             'max_dids' => $this->max_dids,

--- a/backend/app/Models/CallDetailRecord.php
+++ b/backend/app/Models/CallDetailRecord.php
@@ -91,4 +91,17 @@ class CallDetailRecord extends Model
     {
         return $this->hasMany(Recording::class, 'call_uuid', 'uuid');
     }
+
+    /**
+     * The interaction journey for this call, if one was traced.
+     *
+     * CDRs are written by FreeSWITCH and call sessions by the delivery pipeline,
+     * so the two are joined on the channel UUID rather than a foreign key. Not
+     * every CDR has a session — inbound calls that never entered the delivery
+     * path will not.
+     */
+    public function callSession(): HasOne
+    {
+        return $this->hasOne(CallSession::class, 'call_uuid', 'uuid');
+    }
 }

--- a/backend/app/Policies/FlowPolicy.php
+++ b/backend/app/Policies/FlowPolicy.php
@@ -6,6 +6,14 @@ use App\Models\Flow;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
+/**
+ * Authorizes call-flow access.
+ *
+ * The slugs are the declared `flows.*` names. This class used to check
+ * `view-flows` / `manage-flows`, which nothing declared, so the rows never
+ * existed and — once permissions became deny-by-default — flow management was
+ * unreachable for everyone below admin.
+ */
 class FlowPolicy
 {
     use HandlesAuthorization;
@@ -21,7 +29,7 @@ class FlowPolicy
 
     public function viewAny(User $user): bool
     {
-        return $user->hasPermission('view-flows');
+        return $user->hasPermission('flows.view');
     }
 
     public function view(User $user, Flow $flow): bool
@@ -30,12 +38,12 @@ class FlowPolicy
             return false;
         }
 
-        return $user->hasPermission('view-flows');
+        return $user->hasPermission('flows.view');
     }
 
     public function create(User $user): bool
     {
-        return $user->hasPermission('manage-flows');
+        return $user->hasPermission('flows.create');
     }
 
     public function update(User $user, Flow $flow): bool
@@ -44,7 +52,7 @@ class FlowPolicy
             return false;
         }
 
-        return $user->hasPermission('manage-flows');
+        return $user->hasPermission('flows.update');
     }
 
     public function delete(User $user, Flow $flow): bool
@@ -53,6 +61,6 @@ class FlowPolicy
             return false;
         }
 
-        return $user->hasPermission('manage-flows');
+        return $user->hasPermission('flows.delete');
     }
 }

--- a/backend/app/Services/Cdr/CdrSearchService.php
+++ b/backend/app/Services/Cdr/CdrSearchService.php
@@ -4,7 +4,10 @@ namespace App\Services\Cdr;
 
 use App\Models\CallDetailRecord;
 use App\Models\Organization;
+use App\Models\Recording;
+use App\Support\DateRangeFilter;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 
 class CdrSearchService
@@ -14,16 +17,96 @@ class CdrSearchService
      */
     public function search(Organization $organization, Request $request, int $perPage = 25): LengthAwarePaginator
     {
-        // recordings and callSession are eager-loaded so a call-history row can
-        // offer playback and a link to the interaction journey without an
-        // N+1 lookup per row.
-        $query = CallDetailRecord::where('organization_id', $organization->id)
-            ->with(['enrichment', 'recordings', 'callSession:id,call_uuid']);
+        $query = $this->baseQuery($organization, $request);
 
-        // Full-text search across caller/destination numbers
+        // callSession lets a call-history row link to the interaction journey
+        // without an N+1 lookup per row.
+        $query->with('callSession:id,call_uuid');
+
+        $this->applyFilters($query, $request);
+        $this->applySorting($query, $request);
+
+        return $query->paginate(min($perPage, 100));
+    }
+
+    /**
+     * Aggregate counters for the *same* result set `search()` would return.
+     *
+     * The call-history KPI tiles used to come from the analytics summary
+     * endpoint, which only understands a date range — so narrowing the table by
+     * number or direction left the tiles reporting a different, wider set of
+     * calls. Deriving them from the identical filter chain keeps the two in step.
+     */
+    public function summarize(Organization $organization, Request $request): array
+    {
+        $filtered = fn (): Builder => $this->applyFilters(
+            CallDetailRecord::query()->where('organization_id', $organization->id),
+            $request
+        );
+
+        $totalCalls = $filtered()->count();
+        $answeredCalls = $filtered()->whereNotNull('answer_stamp')->count();
+        $totalBillsec = (int) $filtered()->sum('billsec');
+
+        return [
+            'total_calls' => $totalCalls,
+            'answered_calls' => $answeredCalls,
+            'missed_calls' => $filtered()->whereNull('answer_stamp')
+                ->whereIn('hangup_cause', ['NO_ANSWER', 'ALLOTTED_TIMEOUT', 'USER_BUSY'])
+                ->count(),
+            'failed_calls' => $filtered()->whereNull('answer_stamp')
+                ->whereNotIn('hangup_cause', ['NORMAL_CLEARING', 'NO_ANSWER', 'ALLOTTED_TIMEOUT', 'USER_BUSY', 'ORIGINATOR_CANCEL'])
+                ->count(),
+            'total_duration_seconds' => (int) $filtered()->sum('duration'),
+            'total_billsec_seconds' => $totalBillsec,
+            // Answer Seizure Ratio: answered / attempted.
+            'asr' => $totalCalls > 0 ? round(($answeredCalls / $totalCalls) * 100, 1) : 0.0,
+            // Average Call Duration: talk time across answered calls only.
+            'acd_seconds' => $answeredCalls > 0 ? round($totalBillsec / $answeredCalls, 1) : 0.0,
+        ];
+    }
+
+    /**
+     * Organization-scoped query with the relations a list row needs.
+     *
+     * Recordings are only eager-loaded for users allowed to see them; otherwise
+     * the CDR payload would hand recording metadata to anyone who can read call
+     * history, bypassing the recordings permission.
+     */
+    protected function baseQuery(Organization $organization, Request $request): Builder
+    {
+        $query = CallDetailRecord::query()
+            ->where('organization_id', $organization->id)
+            ->with('enrichment');
+
+        if ($this->canViewRecordings($request)) {
+            $query->with('recordings');
+        }
+
+        return $query;
+    }
+
+    /**
+     * Whether the requesting user may see recording metadata.
+     */
+    public function canViewRecordings(Request $request): bool
+    {
+        return (bool) $request->user()?->can('viewAny', Recording::class);
+    }
+
+    /**
+     * Apply every supported filter to a CDR query.
+     *
+     * Shared by list, summary, and export so a filter added in one place cannot
+     * silently go missing in another — the CSV export previously ignored the
+     * `search` box entirely and exported unrelated rows.
+     */
+    public function applyFilters(Builder $query, Request $request): Builder
+    {
+        // Free-text search across caller/destination numbers and the call UUID.
         if ($request->filled('search')) {
             $search = $request->input('search');
-            $query->where(function ($q) use ($search) {
+            $query->where(function (Builder $q) use ($search) {
                 $q->where('caller_id_number', 'LIKE', "%{$search}%")
                     ->orWhere('caller_id_name', 'LIKE', "%{$search}%")
                     ->orWhere('destination_number', 'LIKE', "%{$search}%")
@@ -31,45 +114,20 @@ class CdrSearchService
             });
         }
 
-        // Direction filter
-        if ($request->filled('direction')) {
-            $query->where('direction', $request->input('direction'));
+        foreach (['direction', 'call_type', 'caller_id_number', 'destination_number', 'uuid', 'hangup_cause'] as $column) {
+            if ($request->filled($column)) {
+                $query->where($column, $request->input($column));
+            }
         }
 
-        // Call type filter
-        if ($request->filled('call_type')) {
-            $query->where('call_type', $request->input('call_type'));
-        }
-
-        // Specific number filters
-        if ($request->filled('caller_id_number')) {
-            $query->where('caller_id_number', $request->input('caller_id_number'));
-        }
-
-        if ($request->filled('destination_number')) {
-            $query->where('destination_number', $request->input('destination_number'));
-        }
-
-        // UUID filter
-        if ($request->filled('uuid')) {
-            $query->where('uuid', $request->input('uuid'));
-        }
-
-        // Hangup cause filter
-        if ($request->filled('hangup_cause')) {
-            $query->where('hangup_cause', $request->input('hangup_cause'));
-        }
-
-        // Date range filters
         if ($request->filled('date_from')) {
-            $query->where('start_stamp', '>=', $request->input('date_from'));
+            $query->where('start_stamp', '>=', DateRangeFilter::start($request->input('date_from')));
         }
 
         if ($request->filled('date_to')) {
-            $query->where('start_stamp', '<=', $request->input('date_to'));
+            $query->where('start_stamp', '<=', DateRangeFilter::end($request->input('date_to')));
         }
 
-        // Duration range filters
         if ($request->filled('duration_min')) {
             $query->where('duration', '>=', (int) $request->input('duration_min'));
         }
@@ -78,7 +136,6 @@ class CdrSearchService
             $query->where('duration', '<=', (int) $request->input('duration_max'));
         }
 
-        // Quality filters
         if ($request->filled('quality_score_min')) {
             $query->where('quality_score', '>=', (int) $request->input('quality_score_min'));
         }
@@ -87,7 +144,6 @@ class CdrSearchService
             $query->where('mos_score', '>=', (float) $request->input('mos_score_min'));
         }
 
-        // Tags filter (JSON contains)
         if ($request->filled('tags')) {
             $tags = is_array($request->input('tags'))
                 ? $request->input('tags')
@@ -98,7 +154,6 @@ class CdrSearchService
             }
         }
 
-        // Enrichment filters
         if ($request->filled('destination_country')) {
             $query->whereHas('enrichment', function ($q) use ($request) {
                 $q->where('destination_country', $request->input('destination_country'));
@@ -111,17 +166,21 @@ class CdrSearchService
             });
         }
 
-        // Sorting
-        $sortBy = $request->input('sort_by', 'start_stamp');
-        $sortDir = $request->input('sort_dir', 'desc');
+        return $query;
+    }
+
+    /**
+     * Apply a whitelisted sort, defaulting to newest first.
+     */
+    public function applySorting(Builder $query, Request $request): Builder
+    {
         $allowedSorts = ['start_stamp', 'duration', 'billsec', 'quality_score', 'mos_score', 'caller_id_number', 'destination_number'];
 
-        if (in_array($sortBy, $allowedSorts)) {
-            $query->orderBy($sortBy, $sortDir === 'asc' ? 'asc' : 'desc');
-        } else {
-            $query->orderBy('start_stamp', 'desc');
-        }
+        $sortBy = $request->input('sort_by', 'start_stamp');
+        $sortDir = $request->input('sort_dir', 'desc') === 'asc' ? 'asc' : 'desc';
 
-        return $query->paginate(min($perPage, 100));
+        return in_array($sortBy, $allowedSorts, true)
+            ? $query->orderBy($sortBy, $sortDir)
+            : $query->orderBy('start_stamp', 'desc');
     }
 }

--- a/backend/app/Services/Cdr/CdrSearchService.php
+++ b/backend/app/Services/Cdr/CdrSearchService.php
@@ -14,8 +14,11 @@ class CdrSearchService
      */
     public function search(Organization $organization, Request $request, int $perPage = 25): LengthAwarePaginator
     {
+        // recordings and callSession are eager-loaded so a call-history row can
+        // offer playback and a link to the interaction journey without an
+        // N+1 lookup per row.
         $query = CallDetailRecord::where('organization_id', $organization->id)
-            ->with('enrichment');
+            ->with(['enrichment', 'recordings', 'callSession:id,call_uuid']);
 
         // Full-text search across caller/destination numbers
         if ($request->filled('search')) {

--- a/backend/app/Services/Cdr/CdrSearchService.php
+++ b/backend/app/Services/Cdr/CdrSearchService.php
@@ -39,25 +39,40 @@ class CdrSearchService
      */
     public function summarize(Organization $organization, Request $request): array
     {
-        $filtered = fn (): Builder => $this->applyFilters(
+        // Every counter comes from one pass with conditional aggregates. The
+        // summary rides along on each paginated list request, so issuing a
+        // separate aggregate query per tile would multiply the cost of every
+        // page view over what is typically the largest table in the schema.
+        $missed = ['NO_ANSWER', 'ALLOTTED_TIMEOUT', 'USER_BUSY'];
+        $notFailed = [...$missed, 'NORMAL_CLEARING', 'ORIGINATOR_CANCEL'];
+
+        $missedList = $this->quotedList($missed);
+        $notFailedList = $this->quotedList($notFailed);
+
+        $query = $this->applyFilters(
             CallDetailRecord::query()->where('organization_id', $organization->id),
             $request
         );
 
-        $totalCalls = $filtered()->count();
-        $answeredCalls = $filtered()->whereNotNull('answer_stamp')->count();
-        $totalBillsec = (int) $filtered()->sum('billsec');
+        $row = $query->selectRaw(implode(', ', [
+            'COUNT(*) as total_calls',
+            'SUM(CASE WHEN answer_stamp IS NOT NULL THEN 1 ELSE 0 END) as answered_calls',
+            "SUM(CASE WHEN answer_stamp IS NULL AND hangup_cause IN ({$missedList}) THEN 1 ELSE 0 END) as missed_calls",
+            "SUM(CASE WHEN answer_stamp IS NULL AND (hangup_cause IS NULL OR hangup_cause NOT IN ({$notFailedList})) THEN 1 ELSE 0 END) as failed_calls",
+            'COALESCE(SUM(duration), 0) as total_duration',
+            'COALESCE(SUM(billsec), 0) as total_billsec',
+        ]))->first();
+
+        $totalCalls = (int) ($row->total_calls ?? 0);
+        $answeredCalls = (int) ($row->answered_calls ?? 0);
+        $totalBillsec = (int) ($row->total_billsec ?? 0);
 
         return [
             'total_calls' => $totalCalls,
             'answered_calls' => $answeredCalls,
-            'missed_calls' => $filtered()->whereNull('answer_stamp')
-                ->whereIn('hangup_cause', ['NO_ANSWER', 'ALLOTTED_TIMEOUT', 'USER_BUSY'])
-                ->count(),
-            'failed_calls' => $filtered()->whereNull('answer_stamp')
-                ->whereNotIn('hangup_cause', ['NORMAL_CLEARING', 'NO_ANSWER', 'ALLOTTED_TIMEOUT', 'USER_BUSY', 'ORIGINATOR_CANCEL'])
-                ->count(),
-            'total_duration_seconds' => (int) $filtered()->sum('duration'),
+            'missed_calls' => (int) ($row->missed_calls ?? 0),
+            'failed_calls' => (int) ($row->failed_calls ?? 0),
+            'total_duration_seconds' => (int) ($row->total_duration ?? 0),
             'total_billsec_seconds' => $totalBillsec,
             // Answer Seizure Ratio: answered / attempted.
             'asr' => $totalCalls > 0 ? round(($answeredCalls / $totalCalls) * 100, 1) : 0.0,
@@ -104,8 +119,7 @@ class CdrSearchService
     public function applyFilters(Builder $query, Request $request): Builder
     {
         // Free-text search across caller/destination numbers and the call UUID.
-        if ($request->filled('search')) {
-            $search = $request->input('search');
+        if (($search = $this->scalar($request, 'search')) !== null) {
             $query->where(function (Builder $q) use ($search) {
                 $q->where('caller_id_number', 'LIKE', "%{$search}%")
                     ->orWhere('caller_id_name', 'LIKE', "%{$search}%")
@@ -115,33 +129,33 @@ class CdrSearchService
         }
 
         foreach (['direction', 'call_type', 'caller_id_number', 'destination_number', 'uuid', 'hangup_cause'] as $column) {
-            if ($request->filled($column)) {
-                $query->where($column, $request->input($column));
+            if (($value = $this->scalar($request, $column)) !== null) {
+                $query->where($column, $value);
             }
         }
 
-        if ($request->filled('date_from')) {
-            $query->where('start_stamp', '>=', DateRangeFilter::start($request->input('date_from')));
+        if (($from = $this->scalar($request, 'date_from')) !== null) {
+            $query->where('start_stamp', '>=', DateRangeFilter::start($from));
         }
 
-        if ($request->filled('date_to')) {
-            $query->where('start_stamp', '<=', DateRangeFilter::end($request->input('date_to')));
+        if (($to = $this->scalar($request, 'date_to')) !== null) {
+            $query->where('start_stamp', '<=', DateRangeFilter::end($to));
         }
 
-        if ($request->filled('duration_min')) {
-            $query->where('duration', '>=', (int) $request->input('duration_min'));
+        if (($value = $this->scalar($request, 'duration_min')) !== null) {
+            $query->where('duration', '>=', (int) $value);
         }
 
-        if ($request->filled('duration_max')) {
-            $query->where('duration', '<=', (int) $request->input('duration_max'));
+        if (($value = $this->scalar($request, 'duration_max')) !== null) {
+            $query->where('duration', '<=', (int) $value);
         }
 
-        if ($request->filled('quality_score_min')) {
-            $query->where('quality_score', '>=', (int) $request->input('quality_score_min'));
+        if (($value = $this->scalar($request, 'quality_score_min')) !== null) {
+            $query->where('quality_score', '>=', (int) $value);
         }
 
-        if ($request->filled('mos_score_min')) {
-            $query->where('mos_score', '>=', (float) $request->input('mos_score_min'));
+        if (($value = $this->scalar($request, 'mos_score_min')) !== null) {
+            $query->where('mos_score', '>=', (float) $value);
         }
 
         if ($request->filled('tags')) {
@@ -154,19 +168,52 @@ class CdrSearchService
             }
         }
 
-        if ($request->filled('destination_country')) {
-            $query->whereHas('enrichment', function ($q) use ($request) {
-                $q->where('destination_country', $request->input('destination_country'));
-            });
-        }
-
-        if ($request->filled('number_type')) {
-            $query->whereHas('enrichment', function ($q) use ($request) {
-                $q->where('number_type', $request->input('number_type'));
-            });
+        foreach (['destination_country', 'number_type'] as $column) {
+            if (($value = $this->scalar($request, $column)) !== null) {
+                $query->whereHas('enrichment', fn ($q) => $q->where($column, $value));
+            }
         }
 
         return $query;
+    }
+
+    /**
+     * A filter value as a string, or null when it is absent or not scalar.
+     *
+     * Query strings can carry arrays (`?date_to[]=x`). Handing one to a date
+     * parser or a query binding raised a TypeError and answered 500, so a
+     * non-scalar value is treated as no filter at all.
+     */
+    protected function scalar(Request $request, string $key): ?string
+    {
+        $value = $request->input($key);
+
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $value = (string) $value;
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * Render a fixed list of hangup causes for inlining in a CASE expression.
+     *
+     * The values are class constants rather than user input, but they are quoted
+     * through the connection anyway so this cannot become an injection point if
+     * the list ever grows from somewhere less trusted.
+     *
+     * @param  array<int, string>  $values
+     */
+    protected function quotedList(array $values): string
+    {
+        $pdo = CallDetailRecord::query()->getConnection()->getPdo();
+
+        return implode(', ', array_map(
+            static fn (string $value): string => $pdo->quote($value),
+            $values
+        ));
     }
 
     /**

--- a/backend/app/Services/Cdr/CdrSearchService.php
+++ b/backend/app/Services/Cdr/CdrSearchService.php
@@ -26,7 +26,7 @@ class CdrSearchService
         $this->applyFilters($query, $request);
         $this->applySorting($query, $request);
 
-        return $query->paginate(min($perPage, 100));
+        return $query->paginate(max(1, min($perPage, 100)));
     }
 
     /**

--- a/backend/app/Services/EslConnectionManager.php
+++ b/backend/app/Services/EslConnectionManager.php
@@ -14,10 +14,20 @@ class EslConnectionManager
 
     protected int $retryDelayMs = 500;
 
+    /**
+     * Set once reconnect() has exhausted its retries.
+     *
+     * Without it, every command that calls ensureConnected() pays the full
+     * retry budget again. A single request touching several settings could
+     * spend minutes waiting on a switch that is plainly not answering.
+     */
+    protected bool $unreachable = false;
+
     public function __construct(
         protected string $host,
         protected int $port,
-        protected string $password
+        protected string $password,
+        protected int $timeoutSeconds = 10
     ) {}
 
     /**
@@ -28,7 +38,8 @@ class EslConnectionManager
         return new static(
             config('telephony.freeswitch.host'),
             config('telephony.freeswitch.esl_port'),
-            config('telephony.freeswitch.esl_password')
+            config('telephony.freeswitch.esl_password'),
+            (int) config('telephony.freeswitch.esl_timeout', 10)
         );
     }
 
@@ -37,25 +48,37 @@ class EslConnectionManager
      */
     public function connect(): bool
     {
-        $this->socket = @stream_socket_client(
+        $socket = @stream_socket_client(
             "tcp://{$this->host}:{$this->port}",
             $errno,
             $errstr,
-            timeout: 10
+            timeout: $this->timeoutSeconds
         );
 
-        if (! $this->socket) {
+        if (! $socket) {
             Log::error("ESL connection failed: [{$errno}] {$errstr}");
 
             return false;
         }
 
+        $this->socket = $socket;
+
+        // Bound reads as well as the handshake. A socket that accepts the
+        // connection and then says nothing would otherwise block forever.
+        stream_set_timeout($this->socket, $this->timeoutSeconds);
+
         // Read the initial Content-Type header
         $response = $this->readResponse();
 
-        if (str_contains($response, 'auth/request')) {
-            return $this->authenticate();
+        if (str_contains($response, 'auth/request') && $this->authenticate()) {
+            $this->unreachable = false;
+
+            return true;
         }
+
+        // The socket is open but unusable; leaving it dangling leaks a file
+        // descriptor for the life of the process.
+        $this->disconnect();
 
         return false;
     }
@@ -84,6 +107,7 @@ class EslConnectionManager
         }
 
         Log::error('ESL reconnect failed after '.$this->maxRetries.' attempts');
+        $this->unreachable = true;
 
         return false;
     }
@@ -95,6 +119,10 @@ class EslConnectionManager
     {
         if ($this->isConnected()) {
             return true;
+        }
+
+        if ($this->unreachable) {
+            return false;
         }
 
         return $this->reconnect();

--- a/backend/app/Services/EslConnectionManager.php
+++ b/backend/app/Services/EslConnectionManager.php
@@ -283,9 +283,24 @@ class EslConnectionManager
         $remaining = $length;
         while ($remaining > 0 && ! feof($this->socket)) {
             $chunk = fread($this->socket, min($remaining, 8192));
-            if ($chunk === false) {
-                break;
+
+            // A read timeout returns '' with EOF still false, so an empty chunk
+            // must end the loop — otherwise this spins forever on a switch that
+            // announced a Content-Length and then stopped sending. The body is
+            // truncated either way, so the connection is dropped and the next
+            // command reconnects rather than resuming mid-message.
+            if ($chunk === false || $chunk === '') {
+                Log::warning(sprintf(
+                    'ESL body read incomplete: %d of %d bytes; dropping the connection.',
+                    $length - $remaining,
+                    $length
+                ));
+
+                $this->disconnect();
+
+                return $data;
             }
+
             $data .= $chunk;
             $remaining -= strlen($chunk);
         }

--- a/backend/app/Support/DateRangeFilter.php
+++ b/backend/app/Support/DateRangeFilter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\Exceptions\InvalidFormatException;
+use Illuminate\Support\Carbon;
+
+/**
+ * Widens bare `YYYY-MM-DD` filter values to cover the whole day.
+ *
+ * Date pickers submit a bare date, and comparing `<= 2026-08-12` against a
+ * timestamp column excludes every row on the 12th — so a single-day range that
+ * clearly contains calls came back empty. Values that already carry a time are
+ * passed through untouched.
+ */
+final class DateRangeFilter
+{
+    /**
+     * Lower bound: midnight when only a date was given.
+     */
+    public static function start(string $value): Carbon|string
+    {
+        return self::bound($value, endOfDay: false);
+    }
+
+    /**
+     * Upper bound: the last instant of the day when only a date was given.
+     */
+    public static function end(string $value): Carbon|string
+    {
+        return self::bound($value, endOfDay: true);
+    }
+
+    private static function bound(string $value, bool $endOfDay): Carbon|string
+    {
+        $trimmed = trim($value);
+
+        if (! preg_match('/^\d{4}-\d{2}-\d{2}$/', $trimmed)) {
+            return $value;
+        }
+
+        try {
+            $parsed = Carbon::parse($trimmed);
+        } catch (InvalidFormatException) {
+            // Unparseable input degrades to a literal comparison rather than a 500.
+            return $value;
+        }
+
+        return $endOfDay ? $parsed->endOfDay() : $parsed->startOfDay();
+    }
+}

--- a/backend/config/telephony.php
+++ b/backend/config/telephony.php
@@ -5,6 +5,9 @@ return [
         'host' => env('FREESWITCH_HOST', '127.0.0.1'),
         'esl_port' => (int) env('FREESWITCH_ESL_PORT', 8021),
         'esl_password' => env('FREESWITCH_ESL_PASSWORD', 'ClueCon'),
+        // Connect and read timeout for the event socket. Bounds how long a
+        // web request can wait on an unresponsive switch.
+        'esl_timeout' => (int) env('FREESWITCH_ESL_TIMEOUT', 10),
         'xml_curl_url' => env('FREESWITCH_XML_CURL_URL', '/freeswitch/xml-curl'),
         'log_path' => env('FREESWITCH_LOG_PATH', '/var/log/freeswitch/freeswitch.log'),
         'sip_port' => env('FREESWITCH_SIP_PORT'),

--- a/backend/database/migrations/2026_08_12_090000_index_extension_outbound_policy_foreign_keys.php
+++ b/backend/database/migrations/2026_08_12_090000_index_extension_outbound_policy_foreign_keys.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Index the outbound-policy foreign keys on `extensions`.
+ *
+ * `default_outbound_did_id` and `default_outbound_gateway_id` were added with
+ * `constrained()` but no index. Postgres does not index the referencing side of
+ * a foreign key automatically, so every outbound originate resolves the default
+ * DID and gateway with a sequential scan, and deleting a DID or gateway scans
+ * `extensions` to enforce the constraint.
+ *
+ * `device_profile_id` has the same problem in a subtler form: its only index is
+ * the composite `(organization_id, device_profile_id)`, where it is not the
+ * leading column and so cannot serve a lookup by device alone.
+ */
+return new class extends Migration
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $columns = [
+        'default_outbound_did_id',
+        'default_outbound_gateway_id',
+        'device_profile_id',
+    ];
+
+    public function up(): void
+    {
+        Schema::table('extensions', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->index($column, $this->indexName($column));
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('extensions', function (Blueprint $table) {
+            foreach ($this->columns as $column) {
+                $table->dropIndex($this->indexName($column));
+            }
+        });
+    }
+
+    /**
+     * Named explicitly so `down()` drops exactly what `up()` created, rather
+     * than relying on the generated name matching.
+     */
+    private function indexName(string $column): string
+    {
+        return 'extensions_'.$column.'_index';
+    }
+};

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -34,5 +34,12 @@
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <env name="FREESWITCH_GATEWAY_DIRECTORY" value="storage/framework/testing/gateways"/>
         <env name="FREESWITCH_SIP_PROFILE_DIRECTORY" value="storage/framework/testing/sip_profiles"/>
+        <!--
+            No FreeSWITCH is listening during tests. Code paths that reload the
+            switch after a write tolerate a failed connection, but the default
+            10s connect timeout multiplied across retries made those tests take
+            minutes. 1s keeps the same behaviour without the wait.
+        -->
+        <env name="FREESWITCH_ESL_TIMEOUT" value="1"/>
     </php>
 </phpunit>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -40,6 +40,7 @@ use App\Http\Controllers\Api\PlatformSettingController;
 use App\Http\Controllers\Api\QueueController;
 use App\Http\Controllers\Api\QueueMetricsController;
 use App\Http\Controllers\Api\RecordingController;
+use App\Http\Controllers\Api\RecordingPolicyController;
 use App\Http\Controllers\Api\RegistrationStatusController;
 use App\Http\Controllers\Api\ScheduleController;
 use App\Http\Controllers\Api\SupervisorReportController;
@@ -132,6 +133,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         Route::get('stats', OrganizationStatsController::class)->name('organizations.stats');
         Route::get('provisioning-health', OrganizationProvisioningHealthController::class)->name('organizations.provisioning-health');
         Route::get('directory', [DirectoryController::class, 'index'])->name('directory.index');
+        Route::get('recording-policy/effective', [RecordingPolicyController::class, 'organization'])->name('recording-policy.effective');
 
         // Usage metering
         Route::get('usage/summary', [UsageController::class, 'summary'])->name('organizations.usage.summary');
@@ -141,6 +143,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         // Core resources
         Route::apiResource('extensions', ExtensionController::class);
         Route::get('extensions/{extension}/sip-config', [ExtensionController::class, 'sipConfig'])->name('extensions.sip-config');
+        Route::get('extensions/{extension}/recording-policy/effective', [RecordingPolicyController::class, 'extension'])->name('extensions.recording-policy.effective');
         Route::put('extensions/{extension}/features', [ExtensionFeatureController::class, 'update'])->name('extensions.features.update');
         Route::get('office-features', [OfficeFeatureController::class, 'show'])->name('office-features.show');
         Route::put('office-features', [OfficeFeatureController::class, 'update'])->name('office-features.update');
@@ -159,6 +162,7 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
         Route::post('flows/{flow}/publish', [FlowController::class, 'publish'])->name('flows.publish');
 
         Route::apiResource('dids', DidController::class);
+        Route::get('dids/{did}/recording-policy/effective', [RecordingPolicyController::class, 'did'])->name('dids.recording-policy.effective');
         Route::post('dids/{did}/provider', [NumberProviderController::class, 'store'])->name('dids.provider.store');
         Route::put('dids/{did}/provider', [NumberProviderController::class, 'update'])->name('dids.provider.update');
         Route::delete('dids/{did}/provider', [NumberProviderController::class, 'destroy'])->name('dids.provider.destroy');

--- a/backend/tests/Feature/Api/CallDetailRecordApiTest.php
+++ b/backend/tests/Feature/Api/CallDetailRecordApiTest.php
@@ -184,7 +184,10 @@ class CallDetailRecordApiTest extends TestCase
         $response = $this->actingAs($this->user, 'sanctum')
             ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs/{$cdr->id}");
 
-        $response->assertStatus(403);
+        // The scope check runs before authorization, so a record belonging to
+        // another organization is simply absent from this URL rather than
+        // confirming its existence with a 403.
+        $response->assertStatus(404);
     }
 
     public function test_cdrs_are_ordered_by_start_stamp_desc(): void

--- a/backend/tests/Feature/Api/CallDetailRecordApiTest.php
+++ b/backend/tests/Feature/Api/CallDetailRecordApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\CallDetailRecord;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -21,6 +22,23 @@ class CallDetailRecordApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'cdrs.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['cdrs.view']);
+    }
+
+    /**
+     * CDRs are sensitive — who called whom, when — so an ungranted user must be
+     * denied rather than implicitly allowed.
+     */
+    public function test_user_without_permission_cannot_list_cdrs(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+        CallDetailRecord::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs")
+            ->assertForbidden();
     }
 
     public function test_can_list_cdrs_for_a_organization(): void

--- a/backend/tests/Feature/Api/CallDetailRecordApiTest.php
+++ b/backend/tests/Feature/Api/CallDetailRecordApiTest.php
@@ -176,6 +176,105 @@ class CallDetailRecordApiTest extends TestCase
         $response->assertJsonCount(1, 'data');
     }
 
+    /**
+     * A query string can carry an array. Handing one to the date parser or a
+     * query binding used to raise a TypeError and answer 500.
+     */
+    public function test_array_valued_filters_are_ignored_rather_than_crashing(): void
+    {
+        CallDetailRecord::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs?date_to[]=2026-01-01&date_from[]=2020-01-01&search[]=x&direction[]=inbound")
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_summary_counts_match_the_applied_filters(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'direction' => 'inbound',
+            'answer_stamp' => now(),
+            'billsec' => 60,
+            'hangup_cause' => 'NORMAL_CLEARING',
+        ]);
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'direction' => 'inbound',
+            'answer_stamp' => null,
+            'billsec' => 0,
+            'hangup_cause' => 'NO_ANSWER',
+        ]);
+        // Excluded by the direction filter, so it must not reach the counters.
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'direction' => 'outbound',
+            'answer_stamp' => now(),
+            'billsec' => 600,
+            'hangup_cause' => 'NORMAL_CLEARING',
+        ]);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs?direction=inbound")
+            ->assertOk()
+            ->assertJsonPath('meta.summary.total_calls', 2)
+            ->assertJsonPath('meta.summary.answered_calls', 1)
+            ->assertJsonPath('meta.summary.missed_calls', 1)
+            ->assertJsonPath('meta.summary.failed_calls', 0)
+            // Whole floats serialize without a decimal part, so these are
+            // asserted as the integers the JSON actually carries.
+            ->assertJsonPath('meta.summary.acd_seconds', 60)
+            ->assertJsonPath('meta.summary.asr', 50);
+    }
+
+    public function test_date_to_includes_the_whole_selected_day(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'start_stamp' => '2024-03-04 22:15:00',
+            'uuid' => 'late-in-day',
+        ]);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs?date_from=2024-03-04&date_to=2024-03-04")
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.uuid', 'late-in-day');
+    }
+
+    public function test_recording_data_is_withheld_without_the_recordings_permission(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_path' => '/var/lib/freeswitch/recordings/secret.wav',
+        ]);
+
+        // $this->user holds cdrs.view but not recordings.view.
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs")
+            ->assertOk()
+            ->assertJsonMissingPath('data.0.recording_path')
+            ->assertJsonMissingPath('data.0.has_recording')
+            ->assertJsonMissing(['secret.wav']);
+    }
+
+    public function test_recording_data_is_present_with_the_recordings_permission(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_path' => '/var/lib/freeswitch/recordings/allowed.wav',
+        ]);
+
+        Permission::updateOrCreate(['slug' => 'recordings.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['recordings.view']);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs")
+            ->assertOk()
+            ->assertJsonPath('data.0.has_recording', true);
+    }
+
     public function test_returns_404_for_wrong_organization(): void
     {
         $otherOrganization = Organization::factory()->create();

--- a/backend/tests/Feature/Api/CallEventApiTest.php
+++ b/backend/tests/Feature/Api/CallEventApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\CallEventLog;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -21,6 +22,9 @@ class CallEventApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'call_events.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['call_events.view']);
     }
 
     public function test_can_list_call_events_for_organization(): void

--- a/backend/tests/Feature/Api/CallEventStreamTest.php
+++ b/backend/tests/Feature/Api/CallEventStreamTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -20,6 +21,9 @@ class CallEventStreamTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'call_events.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['call_events.view']);
     }
 
     public function test_stream_endpoint_returns_sse_content_type(): void

--- a/backend/tests/Feature/Api/CallOriginateApiTest.php
+++ b/backend/tests/Feature/Api/CallOriginateApiTest.php
@@ -172,6 +172,13 @@ class CallOriginateApiTest extends TestCase
         $extension->allowedOutboundGateways()->attach($allowedGateway->id);
         $extension->update(['default_outbound_did_id' => $did->id]);
 
+        // A policy rejection must not depend on, or open, a connection to the
+        // switch: the answer comes entirely from stored state.
+        $esl = Mockery::mock();
+        $esl->shouldNotReceive('connect');
+        $esl->shouldNotReceive('bgapi');
+        $this->app->instance(\App\Services\EslConnectionManager::class, $esl);
+
         $response = $this->actingAs($user, 'sanctum')->postJson("/api/v1/organizations/{$organization->id}/calls/originate", [
             'extension' => '1001',
             'destination' => '+15551234567',

--- a/backend/tests/Feature/Api/CallOriginateApiTest.php
+++ b/backend/tests/Feature/Api/CallOriginateApiTest.php
@@ -21,6 +21,28 @@ class CallOriginateApiTest extends TestCase
         parent::tearDown();
     }
 
+    /**
+     * Assert an originate command, ignoring the per-call `origination_uuid`.
+     *
+     * The UUID is generated fresh for every call so it cannot be part of a
+     * literal expectation. Matching the rest of the string exactly still pins
+     * the caller ID, endpoint, and bridge target.
+     */
+    private function matchesOriginate(string $command, string $expectedTail): bool
+    {
+        $prefix = 'originate {origination_uuid=';
+
+        if (! str_starts_with($command, $prefix)) {
+            return false;
+        }
+
+        $remainder = substr($command, strlen($prefix));
+        [$uuid, $tail] = array_pad(explode(',', $remainder, 2), 2, '');
+
+        return $tail === $expectedTail
+            && preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i', $uuid) === 1;
+    }
+
     public function test_originate_uses_extension_default_outbound_did_when_gateway_is_not_supplied(): void
     {
         $organization = Organization::factory()->create(['domain' => 'acme.test']);
@@ -43,9 +65,10 @@ class CallOriginateApiTest extends TestCase
 
         $esl = Mockery::mock();
         $esl->shouldReceive('connect')->once()->andReturnTrue();
-        $esl->shouldReceive('bgapi')->once()->with(
-            'originate {origination_caller_id_name=John Doe,origination_caller_id_number=+15551234567}user/1001@acme.test 2001 XML acme.test'
-        )->andReturn('+OK Job-UUID: test');
+        $esl->shouldReceive('bgapi')->once()->withArgs(fn (string $command): bool => $this->matchesOriginate(
+            $command,
+            'origination_caller_id_name=John Doe,origination_caller_id_number=+15551234567}user/1001@acme.test 2001 XML acme.test'
+        ))->andReturn('+OK Job-UUID: test');
         $esl->shouldReceive('disconnect')->once();
 
         $this->app->instance(\App\Services\EslConnectionManager::class, $esl);
@@ -84,9 +107,12 @@ class CallOriginateApiTest extends TestCase
 
         $esl = Mockery::mock();
         $esl->shouldReceive('connect')->once()->andReturnTrue();
-        $esl->shouldReceive('bgapi')->once()->with(sprintf(
-            'originate {origination_caller_id_name=John Doe,origination_caller_id_number=+15551234567}user/1001@acme.test &bridge(sofia/gateway/v_%s/+15551234567)',
-            $gateway->id,
+        $esl->shouldReceive('bgapi')->once()->withArgs(fn (string $command): bool => $this->matchesOriginate(
+            $command,
+            sprintf(
+                'origination_caller_id_name=John Doe,origination_caller_id_number=+15551234567}user/1001@acme.test &bridge(sofia/gateway/v_%s/+15551234567)',
+                $gateway->id,
+            )
         ))->andReturn('+OK Job-UUID: test');
         $esl->shouldReceive('disconnect')->once();
 

--- a/backend/tests/Feature/Api/CallRoutingPolicyApiTest.php
+++ b/backend/tests/Feature/Api/CallRoutingPolicyApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\CallRoutingPolicy;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -22,6 +23,16 @@ class CallRoutingPolicyApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        foreach (['call_routing_policies.view', 'call_routing_policies.create', 'call_routing_policies.update', 'call_routing_policies.delete'] as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions([
+            'call_routing_policies.view',
+            'call_routing_policies.create',
+            'call_routing_policies.update',
+            'call_routing_policies.delete',
+        ]);
     }
 
     public function test_can_list_call_routing_policies_for_a_organization(): void

--- a/backend/tests/Feature/Api/CdrExportTest.php
+++ b/backend/tests/Feature/Api/CdrExportTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\CallDetailRecord;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -21,6 +22,18 @@ class CdrExportTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'cdrs.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['cdrs.view']);
+    }
+
+    public function test_export_denied_without_cdr_permission(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/cdrs/export")
+            ->assertForbidden();
     }
 
     public function test_export_returns_csv_with_headers(): void
@@ -94,6 +107,50 @@ class CdrExportTest extends TestCase
         $content = $response->streamedContent();
         $this->assertStringContainsString('in-range-uuid', $content);
         $this->assertStringNotContainsString('out-range-uuid', $content);
+    }
+
+    /**
+     * The export used to reimplement its own filter list and silently ignored
+     * the `search` box, so exporting a narrowed table produced a CSV of
+     * unrelated calls.
+     */
+    public function test_export_respects_the_search_filter(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'caller_id_number' => '15551230000',
+            'uuid' => 'matching-uuid',
+        ]);
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'caller_id_number' => '15559990000',
+            'uuid' => 'other-uuid',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->get("/api/v1/organizations/{$this->organization->id}/cdrs/export?search=1555123");
+
+        $content = $response->streamedContent();
+        $this->assertStringContainsString('matching-uuid', $content);
+        $this->assertStringNotContainsString('other-uuid', $content);
+    }
+
+    /**
+     * A bare `YYYY-MM-DD` upper bound has to cover the whole day; comparing it
+     * against a timestamp otherwise drops every call on the selected date.
+     */
+    public function test_export_date_to_includes_the_whole_selected_day(): void
+    {
+        CallDetailRecord::factory()->create([
+            'organization_id' => $this->organization->id,
+            'start_stamp' => '2024-01-15 23:45:00',
+            'uuid' => 'late-in-day-uuid',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->get("/api/v1/organizations/{$this->organization->id}/cdrs/export?date_from=2024-01-15&date_to=2024-01-15");
+
+        $this->assertStringContainsString('late-in-day-uuid', $response->streamedContent());
     }
 
     public function test_export_requires_authentication(): void

--- a/backend/tests/Feature/Api/DeviceProfileApiTest.php
+++ b/backend/tests/Feature/Api/DeviceProfileApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use App\Models\DeviceProfile;
 use App\Models\Extension;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -22,6 +23,24 @@ class DeviceProfileApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // device profile abilities these cases exercise rather than relying on
+        // a permissive fallback.
+        $slugs = ['device_profiles.view', 'device_profiles.create', 'device_profiles.update', 'device_profiles.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_list_device_profiles(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/device-profiles")
+            ->assertForbidden();
     }
 
     public function test_can_list_device_profiles_for_a_organization(): void

--- a/backend/tests/Feature/Api/DidApiTest.php
+++ b/backend/tests/Feature/Api/DidApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use App\Models\Did;
 use App\Models\Gateway;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -23,6 +24,24 @@ class DidApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // DID abilities these cases exercise rather than relying on a
+        // permissive fallback.
+        $slugs = ['dids.view', 'dids.create', 'dids.update', 'dids.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_list_dids(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/dids")
+            ->assertForbidden();
     }
 
     public function test_can_list_dids_for_a_organization(): void
@@ -118,7 +137,14 @@ class DidApiTest extends TestCase
 
     public function test_can_update_a_did_recording_policy(): void
     {
-        $did = Did::factory()->create(['organization_id' => $this->organization->id]);
+        // Pinned to 'extension': the factory's default destination_type is a
+        // random pick that can land outside the update endpoint's
+        // extension|flow enum, making this test flaky independent of
+        // permissions.
+        $did = Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'destination_type' => 'extension',
+        ]);
 
         $response = $this->actingAs($this->user, 'sanctum')
             ->putJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}", [
@@ -137,7 +163,6 @@ class DidApiTest extends TestCase
             'recording_policy' => 'incoming',
         ]);
     }
-
 
     public function test_can_delete_a_did(): void
     {

--- a/backend/tests/Feature/Api/DidUniquenessTest.php
+++ b/backend/tests/Feature/Api/DidUniquenessTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Did;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -22,6 +23,29 @@ class DidUniquenessTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // DID abilities these cases exercise rather than relying on a
+        // permissive fallback.
+        $slugs = ['dids.create', 'dids.update'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_create_a_did(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->postJson("/api/v1/organizations/{$this->organization->id}/dids", [
+                'number' => '+15551234567',
+                'destination_type' => 'extension',
+                'destination_id' => Str::uuid()->toString(),
+                'is_active' => true,
+            ])
+            ->assertForbidden();
     }
 
     public function test_cannot_create_duplicate_did_number_within_same_organization(): void
@@ -49,6 +73,7 @@ class DidUniquenessTest extends TestCase
     {
         $organizationB = Organization::factory()->create();
         $userB = User::factory()->create(['organization_id' => $organizationB->id]);
+        $userB->grantPermissions(['dids.create']);
 
         // Create DID in organization A
         $this->organization->dids()->create([
@@ -79,11 +104,14 @@ class DidUniquenessTest extends TestCase
             'is_active' => true,
         ]);
 
+        // 'voicemail' isn't in UpdateDidRequest's extension|flow enum, so the
+        // update endpoint would 422 regardless of the number check this test
+        // targets; use 'flow' to still exercise a destination_type change.
         $response = $this->actingAs($this->user, 'sanctum')
             ->putJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}", [
                 'number' => '+15551234567',
                 'description' => 'Updated description',
-                'destination_type' => 'voicemail',
+                'destination_type' => 'flow',
                 'destination_id' => Str::uuid()->toString(),
             ]);
 

--- a/backend/tests/Feature/Api/EffectiveRecordingPolicyTest.php
+++ b/backend/tests/Feature/Api/EffectiveRecordingPolicyTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Did;
+use App\Models\Extension;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EffectiveRecordingPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Organization $organization;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->organization = Organization::factory()->create(['recording_policy' => 'off']);
+        $this->user = User::factory()->create([
+            'organization_id' => $this->organization->id,
+            'role' => 'admin',
+        ]);
+    }
+
+    public function test_can_resolve_organization_scope(): void
+    {
+        $this->organization->update(['recording_policy' => 'all']);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.scope', 'organization');
+        $response->assertJsonPath('data.inbound.resolved_mode', 'all');
+        $response->assertJsonPath('data.inbound.should_record', true);
+        $response->assertJsonPath('data.inbound.winning_scope', 'organization');
+        $response->assertJsonPath('data.outbound.resolved_mode', 'all');
+        $response->assertJsonPath('data.outbound.should_record', true);
+        $response->assertJsonPath('data.outbound.winning_scope', 'organization');
+    }
+
+    public function test_organization_scope_with_inherit_resolves_to_nothing(): void
+    {
+        // "inherit" is not offered in the organization form anymore, but the
+        // backend still accepts it for compatibility. At organization scope
+        // there is nothing above it to inherit from, so it silently resolves
+        // to "no policy" (not recording) rather than "all"/"off".
+        $this->organization->update(['recording_policy' => 'inherit']);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.inbound.should_record', false);
+        $response->assertJsonPath('data.inbound.winning_scope', null);
+    }
+
+    public function test_can_resolve_did_scope_inheriting_from_organization(): void
+    {
+        $this->organization->update(['recording_policy' => 'incoming']);
+        $did = Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'inherit',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.scope', 'did');
+        $response->assertJsonPath('data.inbound.resolved_mode', 'incoming');
+        $response->assertJsonPath('data.inbound.should_record', true);
+        $response->assertJsonPath('data.inbound.winning_scope', 'organization');
+        // "incoming" does not match the outbound direction, so it does not record,
+        // but the resolved mode/winning scope are still surfaced.
+        $response->assertJsonPath('data.outbound.resolved_mode', 'incoming');
+        $response->assertJsonPath('data.outbound.should_record', false);
+        $response->assertJsonPath('data.outbound.winning_scope', 'organization');
+    }
+
+    public function test_did_off_wins_over_organization_all(): void
+    {
+        $this->organization->update(['recording_policy' => 'all']);
+        $did = Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'off',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.inbound.resolved_mode', 'off');
+        $response->assertJsonPath('data.inbound.should_record', false);
+        $response->assertJsonPath('data.inbound.winning_scope', 'did');
+        $response->assertJsonPath('data.outbound.resolved_mode', 'off');
+        $response->assertJsonPath('data.outbound.should_record', false);
+        $response->assertJsonPath('data.outbound.winning_scope', 'did');
+    }
+
+    public function test_can_resolve_extension_scope_inheriting_from_default_outbound_did(): void
+    {
+        $this->organization->update(['recording_policy' => 'off']);
+        $did = Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'all',
+        ]);
+        $extension = Extension::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'inherit',
+            'default_outbound_did_id' => $did->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.scope', 'extension');
+        $response->assertJsonPath('data.inbound.resolved_mode', 'all');
+        $response->assertJsonPath('data.inbound.should_record', true);
+        $response->assertJsonPath('data.inbound.winning_scope', 'did');
+        $response->assertJsonPath('data.outbound.resolved_mode', 'all');
+        $response->assertJsonPath('data.outbound.should_record', true);
+        $response->assertJsonPath('data.outbound.winning_scope', 'did');
+    }
+
+    public function test_extension_off_wins_over_organization_all(): void
+    {
+        $this->organization->update(['recording_policy' => 'all']);
+        $extension = Extension::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'off',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.inbound.resolved_mode', 'off');
+        $response->assertJsonPath('data.inbound.should_record', false);
+        $response->assertJsonPath('data.inbound.winning_scope', 'extension');
+        $response->assertJsonPath('data.outbound.resolved_mode', 'off');
+        $response->assertJsonPath('data.outbound.should_record', false);
+        $response->assertJsonPath('data.outbound.winning_scope', 'extension');
+    }
+
+    public function test_extension_without_default_outbound_did_falls_back_to_organization(): void
+    {
+        $this->organization->update(['recording_policy' => 'outgoing']);
+        $extension = Extension::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'inherit',
+            'default_outbound_did_id' => null,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonPath('data.outbound.resolved_mode', 'outgoing');
+        $response->assertJsonPath('data.outbound.should_record', true);
+        $response->assertJsonPath('data.outbound.winning_scope', 'organization');
+    }
+
+    public function test_did_from_another_organization_returns_404_for_superadmin(): void
+    {
+        $otherOrganization = Organization::factory()->create();
+        $did = Did::factory()->create(['organization_id' => $otherOrganization->id]);
+        $superadmin = User::factory()->create(['role' => 'superadmin', 'organization_id' => null]);
+
+        $response = $this->actingAs($superadmin, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}/recording-policy/effective");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_extension_from_another_organization_returns_404_for_superadmin(): void
+    {
+        $otherOrganization = Organization::factory()->create();
+        $extension = Extension::factory()->create(['organization_id' => $otherOrganization->id]);
+        $superadmin = User::factory()->create(['role' => 'superadmin', 'organization_id' => null]);
+
+        $response = $this->actingAs($superadmin, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_unauthorized_user_is_denied_for_organization_scope(): void
+    {
+        $agent = User::factory()->create([
+            'organization_id' => $this->organization->id,
+            'role' => 'agent',
+        ]);
+
+        $response = $this->actingAs($agent, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/recording-policy/effective");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_unauthorized_user_is_denied_for_did_scope(): void
+    {
+        $did = Did::factory()->create(['organization_id' => $this->organization->id]);
+        $agent = User::factory()->create([
+            'organization_id' => $this->organization->id,
+            'role' => 'agent',
+        ]);
+
+        $response = $this->actingAs($agent, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/dids/{$did->id}/recording-policy/effective");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_unauthorized_user_is_denied_for_extension_scope(): void
+    {
+        $extension = Extension::factory()->create(['organization_id' => $this->organization->id]);
+        $agent = User::factory()->create([
+            'organization_id' => $this->organization->id,
+            'role' => 'agent',
+        ]);
+
+        $response = $this->actingAs($agent, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertStatus(403);
+    }
+}

--- a/backend/tests/Feature/Api/EffectiveRecordingPolicyTest.php
+++ b/backend/tests/Feature/Api/EffectiveRecordingPolicyTest.php
@@ -103,7 +103,13 @@ class EffectiveRecordingPolicyTest extends TestCase
         $response->assertJsonPath('data.outbound.winning_scope', 'did');
     }
 
-    public function test_can_resolve_extension_scope_inheriting_from_default_outbound_did(): void
+    /**
+     * The default outbound DID only applies to calls the extension places. An
+     * inbound call arrives on whichever number routed to the extension, so
+     * attributing the outbound DID's policy to it advertised a policy that would
+     * never actually apply.
+     */
+    public function test_default_outbound_did_shapes_outbound_only(): void
     {
         $this->organization->update(['recording_policy' => 'off']);
         $did = Did::factory()->create([
@@ -121,12 +127,60 @@ class EffectiveRecordingPolicyTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonPath('data.scope', 'extension');
-        $response->assertJsonPath('data.inbound.resolved_mode', 'all');
-        $response->assertJsonPath('data.inbound.should_record', true);
-        $response->assertJsonPath('data.inbound.winning_scope', 'did');
+        $response->assertJsonPath('data.inbound.resolved_mode', 'off');
+        $response->assertJsonPath('data.inbound.should_record', false);
+        $response->assertJsonPath('data.inbound.winning_scope', 'organization');
         $response->assertJsonPath('data.outbound.resolved_mode', 'all');
         $response->assertJsonPath('data.outbound.should_record', true);
         $response->assertJsonPath('data.outbound.winning_scope', 'did');
+    }
+
+    /**
+     * Numbers pointed straight at the extension are listed so an admin can see
+     * which inbound calls will not follow the extension's own policy.
+     */
+    public function test_extension_lists_inbound_dids_that_override_it(): void
+    {
+        $this->organization->update(['recording_policy' => 'off']);
+        $extension = Extension::factory()->create([
+            'organization_id' => $this->organization->id,
+            'recording_policy' => 'all',
+        ]);
+
+        $overriding = Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'number' => '15551110000',
+            'recording_policy' => 'off',
+            'destination_type' => 'extension',
+            'destination_id' => $extension->id,
+        ]);
+
+        // Inheriting numbers defer to the extension, so they are not overrides.
+        Did::factory()->create([
+            'organization_id' => $this->organization->id,
+            'number' => '15552220000',
+            'recording_policy' => 'inherit',
+            'destination_type' => 'extension',
+            'destination_id' => $extension->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective");
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'data.inbound_did_overrides');
+        $response->assertJsonPath('data.inbound_did_overrides.0.id', (string) $overriding->id);
+        $response->assertJsonPath('data.inbound_did_overrides.0.recording_policy', 'off');
+    }
+
+    public function test_cross_organization_extension_is_not_found(): void
+    {
+        $other = Organization::factory()->create();
+        $extension = Extension::factory()->create(['organization_id' => $other->id]);
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions/{$extension->id}/recording-policy/effective")
+            ->assertNotFound();
     }
 
     public function test_extension_off_wins_over_organization_all(): void

--- a/backend/tests/Feature/Api/ExtensionApiTest.php
+++ b/backend/tests/Feature/Api/ExtensionApiTest.php
@@ -9,6 +9,7 @@ use App\Models\FlowNode;
 use App\Models\FlowVersion;
 use App\Models\Organization;
 use App\Models\OrganizationDialplanManifest;
+use App\Models\Permission;
 use App\Models\Team;
 use App\Models\TeamMember;
 use App\Models\User;
@@ -33,6 +34,58 @@ class ExtensionApiTest extends TestCase
             'domain' => 'test.example.com',
         ]);
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // extension abilities these cases exercise rather than relying on a
+        // permissive fallback.
+        $slugs = ['extensions.view', 'extensions.create', 'extensions.update', 'extensions.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_list_extensions(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions")
+            ->assertForbidden();
+    }
+
+    public function test_view_permission_alone_cannot_create_an_extension(): void
+    {
+        $viewer = User::factory()->create(['organization_id' => $this->organization->id]);
+        $viewer->grantPermissions(['extensions.view']);
+
+        $this->actingAs($viewer, 'sanctum')
+            ->postJson("/api/v1/organizations/{$this->organization->id}/extensions", [
+                'extension' => '199',
+                'password' => 'secret1234',
+                'first_name' => 'Read',
+                'last_name' => 'Only',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_per_page_is_honoured_when_listing_extensions(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $this->organization->extensions()->create([
+                'extension' => (string) (200 + $i),
+                'password' => 'secret1234',
+                'first_name' => 'Seat',
+                'last_name' => (string) $i,
+            ]);
+        }
+
+        // The default page size is 15; pickers that resolve an extension number
+        // to a name need the whole list or they label the remainder unknown.
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/extensions?per_page=100")
+            ->assertOk()
+            ->assertJsonCount(20, 'data');
     }
 
     public function test_can_list_extensions_for_a_organization(): void

--- a/backend/tests/Feature/Api/ExtensionOutboundPolicySyncTest.php
+++ b/backend/tests/Feature/Api/ExtensionOutboundPolicySyncTest.php
@@ -6,6 +6,7 @@ use App\Models\DeviceProfile;
 use App\Models\Did;
 use App\Models\Gateway;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use App\Services\OrganizationManifestBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,6 +23,12 @@ class ExtensionOutboundPolicySyncTest extends TestCase
             'domain' => 'test.example.com',
         ]);
         $user = User::factory()->create(['organization_id' => $organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // extension ability this case exercises rather than relying on a
+        // permissive fallback.
+        Permission::updateOrCreate(['slug' => 'extensions.update'], ['module' => 'core']);
+        $user->grantPermissions(['extensions.update']);
 
         $gateway = Gateway::factory()->create([
             'organization_id' => $organization->id,
@@ -75,5 +82,30 @@ class ExtensionOutboundPolicySyncTest extends TestCase
 
         $profile->refresh();
         $this->assertGreaterThan($originalUpdatedAt, $profile->updated_at);
+    }
+
+    public function test_user_without_permission_cannot_update_outbound_policy(): void
+    {
+        $organization = Organization::create([
+            'name' => 'Test Organization',
+            'domain' => 'test.example.com',
+        ]);
+        $unprivileged = User::factory()->create(['organization_id' => $organization->id]);
+        $extension = $organization->extensions()->create([
+            'extension' => '101',
+            'password' => 'secret1234',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->putJson("/api/v1/organizations/{$organization->id}/extensions/{$extension->id}", [
+                'extension' => '101',
+                'password' => 'secret1234',
+                'first_name' => 'John',
+                'last_name' => 'Doe',
+            ])
+            ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/Api/GatewaySchemaApiTest.php
+++ b/backend/tests/Feature/Api/GatewaySchemaApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -15,6 +16,12 @@ class GatewaySchemaApiTest extends TestCase
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // gateway ability this case exercises rather than relying on a
+        // permissive fallback.
+        Permission::updateOrCreate(['slug' => 'gateways.manage'], ['module' => 'module']);
+        $user->grantPermissions(['gateways.manage']);
 
         $payload = [
             'name' => 'Carrier A',
@@ -47,5 +54,18 @@ class GatewaySchemaApiTest extends TestCase
             ->assertJsonPath('data.expire_seconds', 600)
             ->assertJsonPath('data.retry_seconds', 15)
             ->assertJsonPath('data.profile', 'external');
+    }
+
+    public function test_user_without_permission_cannot_create_a_gateway(): void
+    {
+        $organization = Organization::factory()->create();
+        $unprivileged = User::factory()->create(['organization_id' => $organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->postJson("/api/v1/organizations/{$organization->id}/gateways", [
+                'name' => 'Carrier A',
+                'host' => 'sip.carrier.test',
+            ])
+            ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/Api/IvrApiTest.php
+++ b/backend/tests/Feature/Api/IvrApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Api;
 
 use App\Models\Ivr;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -22,6 +23,24 @@ class IvrApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // IVR abilities these cases exercise rather than relying on a
+        // permissive fallback.
+        $slugs = ['ivrs.view', 'ivrs.create', 'ivrs.update', 'ivrs.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_list_ivrs(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/ivrs")
+            ->assertForbidden();
     }
 
     public function test_can_list_ivrs_for_a_organization(): void

--- a/backend/tests/Feature/Api/MobileDeviceApiTest.php
+++ b/backend/tests/Feature/Api/MobileDeviceApiTest.php
@@ -6,6 +6,7 @@ use App\Models\DeviceProfile;
 use App\Models\EndpointBinding;
 use App\Models\Extension;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -28,6 +29,31 @@ class MobileDeviceApiTest extends TestCase
 
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // endpoint-binding abilities these cases exercise rather than relying
+        // on a permissive fallback.
+        $slugs = ['endpoint_bindings.create', 'endpoint_bindings.update', 'endpoint_bindings.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_register_a_mobile_device(): void
+    {
+        $extension = Extension::factory()->create(['organization_id' => $this->organization->id]);
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->postJson("/api/v1/organizations/{$this->organization->id}/mobile-devices/register", [
+                'extension_id' => $extension->id,
+                'device_uuid' => 'device-456',
+                'platform' => EndpointBinding::PLATFORM_IOS,
+                'push_token' => 'push-token',
+                'app_version' => '1.0.0',
+            ])
+            ->assertForbidden();
     }
 
     public function test_can_register_a_mobile_device_for_a_organization(): void

--- a/backend/tests/Feature/Api/OrganizationApiTest.php
+++ b/backend/tests/Feature/Api/OrganizationApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -18,7 +19,14 @@ class OrganizationApiTest extends TestCase
 
     private function organizationUser(Organization $organization): User
     {
-        return User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
+        $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
+
+        // Permissions are deny-by-default, so this non-admin fixture needs an
+        // explicit grant to view its own organization.
+        Permission::updateOrCreate(['slug' => 'organizations.view'], ['module' => 'core']);
+        $user->grantPermissions(['organizations.view']);
+
+        return $user;
     }
 
     public function test_unauthenticated_requests_return_401(): void
@@ -64,6 +72,19 @@ class OrganizationApiTest extends TestCase
         $response->assertStatus(200);
         $response->assertJsonFragment(['name' => 'My Organization']);
         $response->assertJsonMissing(['name' => 'Other Organization']);
+    }
+
+    public function test_user_without_permission_cannot_list_organizations(): void
+    {
+        $organization = Organization::create([
+            'name' => 'Unprivileged Org',
+            'domain' => 'unprivileged.example.com',
+        ]);
+        $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
+
+        $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/organizations')
+            ->assertForbidden();
     }
 
     public function test_admin_can_create_a_organization(): void

--- a/backend/tests/Feature/Api/OrganizationProvisioningHealthApiTest.php
+++ b/backend/tests/Feature/Api/OrganizationProvisioningHealthApiTest.php
@@ -8,6 +8,7 @@ use App\Models\Flow;
 use App\Models\HolidayCalendar;
 use App\Models\Organization;
 use App\Models\OrganizationDialplanManifest;
+use App\Models\Permission;
 use App\Models\Schedule;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -70,11 +71,30 @@ class OrganizationProvisioningHealthApiTest extends TestCase
             'organization_id' => $organization->id,
         ]);
 
+        // Permissions are deny-by-default; this endpoint reuses the
+        // organization "view" ability.
+        Permission::updateOrCreate(['slug' => 'organizations.view'], ['module' => 'core']);
+        $user->grantPermissions(['organizations.view']);
+
         $response = $this->actingAs($user, 'sanctum')
             ->getJson("/api/v1/organizations/{$organization->id}/provisioning-health");
 
         $response->assertOk()
             ->assertJsonPath('data.status', 'ready');
+    }
+
+    public function test_agent_without_permission_cannot_view_organization_provisioning_health(): void
+    {
+        $organization = $this->makeProvisionedOrganization();
+        $user = User::factory()->create([
+            'role' => 'agent',
+            'organization_id' => $organization->id,
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$organization->id}/provisioning-health");
+
+        $response->assertForbidden();
     }
 
     public function test_other_organization_user_is_blocked_by_organization_access(): void

--- a/backend/tests/Feature/Api/OrganizationStatsTest.php
+++ b/backend/tests/Feature/Api/OrganizationStatsTest.php
@@ -3,13 +3,14 @@
 namespace Tests\Feature\Api;
 
 use App\Models\CallDetailRecord;
-use App\Models\Flow;
 use App\Models\CallRoutingPolicy;
 use App\Models\DeviceProfile;
 use App\Models\Did;
 use App\Models\Extension;
+use App\Models\Flow;
 use App\Models\Ivr;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\Recording;
 use App\Models\Team;
 use App\Models\User;
@@ -95,10 +96,28 @@ class OrganizationStatsTest extends TestCase
             'role' => 'agent',
         ]);
 
+        // Permissions are deny-by-default; viewing stats reuses the
+        // organization "view" ability.
+        Permission::updateOrCreate(['slug' => 'organizations.view'], ['module' => 'core']);
+        $user->grantPermissions(['organizations.view']);
+
         $response = $this->actingAs($user, 'sanctum')
             ->getJson("/api/v1/organizations/{$this->organization->id}/stats");
 
         $response->assertStatus(200);
+    }
+
+    public function test_user_without_permission_cannot_access_stats(): void
+    {
+        $user = User::factory()->create([
+            'organization_id' => $this->organization->id,
+            'role' => 'agent',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/stats");
+
+        $response->assertForbidden();
     }
 
     public function test_different_organization_user_gets_403(): void

--- a/backend/tests/Feature/Api/RecordingApiTest.php
+++ b/backend/tests/Feature/Api/RecordingApiTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Feature\Api;
 
-use App\Models\Recording;
 use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Recording;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -21,6 +22,39 @@ class RecordingApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default. Recordings split view/download/delete
+        // into distinct slugs on purpose, so only grant what these cases need
+        // rather than the full set.
+        $slugs = ['recordings.view', 'recordings.download', 'recordings.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions(['recordings.view', 'recordings.delete']);
+    }
+
+    public function test_user_without_permission_cannot_list_recordings(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/recordings")
+            ->assertForbidden();
+    }
+
+    public function test_view_permission_alone_cannot_download_or_delete_a_recording(): void
+    {
+        $recording = Recording::factory()->create(['organization_id' => $this->organization->id]);
+        $viewer = User::factory()->create(['organization_id' => $this->organization->id]);
+        $viewer->grantPermissions(['recordings.view']);
+
+        $this->actingAs($viewer, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/recordings/{$recording->id}/download")
+            ->assertForbidden();
+
+        $this->actingAs($viewer, 'sanctum')
+            ->deleteJson("/api/v1/organizations/{$this->organization->id}/recordings/{$recording->id}")
+            ->assertForbidden();
     }
 
     public function test_can_list_recordings(): void

--- a/backend/tests/Feature/Api/TimeConditionApiTest.php
+++ b/backend/tests/Feature/Api/TimeConditionApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\TimeCondition;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,6 +23,24 @@ class TimeConditionApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // time-condition abilities these cases exercise rather than relying
+        // on a permissive fallback.
+        $slugs = ['time_conditions.view', 'time_conditions.create', 'time_conditions.update', 'time_conditions.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
+    }
+
+    public function test_user_without_permission_cannot_list_time_conditions(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/time-conditions")
+            ->assertForbidden();
     }
 
     public function test_can_list_time_conditions_for_a_organization(): void

--- a/backend/tests/Feature/Api/WebhookApiTest.php
+++ b/backend/tests/Feature/Api/WebhookApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use App\Models\Webhook;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,6 +22,15 @@ class WebhookApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default, so the acting user is granted the
+        // webhook abilities these cases exercise rather than relying on a
+        // permissive fallback.
+        $slugs = ['webhooks.view', 'webhooks.create', 'webhooks.update', 'webhooks.delete'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->user->grantPermissions($slugs);
     }
 
     public function test_can_list_webhooks_for_a_organization(): void
@@ -97,5 +107,14 @@ class WebhookApiTest extends TestCase
 
         $response->assertStatus(422);
         $response->assertJsonValidationErrors(['url', 'events']);
+    }
+
+    public function test_user_without_permission_cannot_list_webhooks(): void
+    {
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/webhooks")
+            ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/Api/WebhookDeliveryAttemptApiTest.php
+++ b/backend/tests/Feature/Api/WebhookDeliveryAttemptApiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Api;
 
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use App\Models\Webhook;
 use App\Models\WebhookDeliveryAttempt;
@@ -22,6 +23,11 @@ class WebhookDeliveryAttemptApiTest extends TestCase
         parent::setUp();
         $this->organization = Organization::factory()->create();
         $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        // Permissions are deny-by-default; delivery attempts are viewed
+        // through the webhook's "view" ability.
+        Permission::updateOrCreate(['slug' => 'webhooks.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['webhooks.view']);
     }
 
     public function test_can_list_delivery_attempts_for_a_webhook(): void
@@ -66,5 +72,15 @@ class WebhookDeliveryAttemptApiTest extends TestCase
             ->getJson("/api/v1/organizations/{$this->organization->id}/webhooks/{$webhook->id}/delivery-attempts");
 
         $response->assertStatus(404);
+    }
+
+    public function test_user_without_permission_cannot_list_delivery_attempts(): void
+    {
+        $webhook = Webhook::factory()->create(['organization_id' => $this->organization->id]);
+        $unprivileged = User::factory()->create(['organization_id' => $this->organization->id]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organization->id}/webhooks/{$webhook->id}/delivery-attempts")
+            ->assertForbidden();
     }
 }

--- a/backend/tests/Feature/Api/WebhookEventExpansionTest.php
+++ b/backend/tests/Feature/Api/WebhookEventExpansionTest.php
@@ -92,7 +92,7 @@ class WebhookEventExpansionTest extends TestCase
         // Create extension
         $response = $this->actingAs($user, 'sanctum')
             ->postJson("/api/v1/organizations/{$organization->id}/extensions", [
-                'extension' => '1001',
+                'extension' => '101',
                 'password' => 'secret123456',
                 'first_name' => 'Test',
                 'last_name' => 'User',

--- a/backend/tests/Feature/Audit/SystemCheckpointAuditTest.php
+++ b/backend/tests/Feature/Audit/SystemCheckpointAuditTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Audit;
 
 use App\Models\Agent;
 use App\Models\CallEventLog;
+use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\Queue;
 use App\Models\QueueEntry;
 use App\Models\Recording;
-use App\Models\Organization;
 use App\Models\User;
 use App\Models\Webhook;
 use App\Services\DialplanCompiler;
@@ -72,6 +73,15 @@ class SystemCheckpointAuditTest extends TestCase
             'role' => 'admin',
             'organization_id' => null,
         ]);
+
+        // Permissions are deny-by-default; grant userA exactly the abilities
+        // this audit's positive-path cases exercise (extensions list, webhooks
+        // list). userB stays ungranted since its cases assert isolation denial.
+        $slugs = ['extensions.view', 'webhooks.view'];
+        foreach ($slugs as $slug) {
+            Permission::updateOrCreate(['slug' => $slug], ['module' => 'core']);
+        }
+        $this->userA->grantPermissions($slugs);
     }
 
     // ========================================================================
@@ -131,6 +141,18 @@ class SystemCheckpointAuditTest extends TestCase
         $response = $this->actingAs($this->userA, 'sanctum')
             ->getJson("/api/v1/organizations/{$this->organizationA->id}/extensions");
         $response->assertStatus(200);
+    }
+
+    public function test_cp1_user_without_permission_cannot_list_extensions(): void
+    {
+        $unprivileged = User::factory()->create([
+            'organization_id' => $this->organizationA->id,
+            'role' => 'agent',
+        ]);
+
+        $this->actingAs($unprivileged, 'sanctum')
+            ->getJson("/api/v1/organizations/{$this->organizationA->id}/extensions")
+            ->assertForbidden();
     }
 
     // ========================================================================

--- a/backend/tests/Feature/FlowCompilerSnapshotTest.php
+++ b/backend/tests/Feature/FlowCompilerSnapshotTest.php
@@ -6,8 +6,8 @@ use App\Models\Flow;
 use App\Models\FlowEdge;
 use App\Models\FlowNode;
 use App\Models\FlowVersion;
-use App\Models\RingGroup;
 use App\Models\Organization;
+use App\Models\RingGroup;
 use App\Services\Flow\FlowArtifactService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -17,6 +17,7 @@ class FlowCompilerSnapshotTest extends TestCase
     use RefreshDatabase;
 
     protected FlowArtifactService $artifactService;
+
     protected Organization $organization;
 
     protected function setUp(): void
@@ -37,7 +38,7 @@ class FlowCompilerSnapshotTest extends TestCase
             'id' => '11111111-1111-1111-1111-111111111111',
             'organization_id' => $this->organization->id,
         ]);
-        
+
         $flowVersion = FlowVersion::factory()->create([
             'flow_id' => $flow->id,
             'status' => 'draft',
@@ -126,7 +127,7 @@ class FlowCompilerSnapshotTest extends TestCase
         $this->assertTrue($result['success'], $result['error'] ?? json_encode($result));
 
         $artifact = \App\Models\FlowCompiledArtifact::find($result['artifact_id']);
-        
+
         // We assert against a known snapshot string
         $expectedXml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
@@ -201,15 +202,15 @@ class FlowCompilerSnapshotTest extends TestCase
 XML;
 
         // Note: For simplicity and dealing with non-deterministic node array ordering from DB query
-        // we'll just check that each expected block exists. 
+        // we'll just check that each expected block exists.
         // Real snapshot testing would freeze DB ordering or sort nodes.
-        
+
         $this->assertStringContainsString('<extension name="flow_11111111-1111-1111-1111-111111111111">', $artifact->content);
         $this->assertStringContainsString('<action application="transfer" data="node_10000000-0000-0000-0000-000000000001 XML snapshot.example.com"/>', $artifact->content);
-        
+
         // Start node check
         $this->assertStringContainsString('<action application="transfer" data="node_10000000-0000-0000-0000-000000000002 XML snapshot.example.com"/>', $artifact->content);
-        $this->assertStringNotContainsString('<extension name="node_10000000-0000-0000-0000-000000000001">' . "\n" . '        <condition field="destination_number" expression="^node_10000000-0000-0000-0000-000000000001$">' . "\n" . '          <action application="answer"/>', $artifact->content);
+        $this->assertStringNotContainsString('<extension name="node_10000000-0000-0000-0000-000000000001">'."\n".'        <condition field="destination_number" expression="^node_10000000-0000-0000-0000-000000000001$">'."\n".'          <action application="answer"/>', $artifact->content);
 
         // Schedule check
         $this->assertStringContainsString('<action application="set" data="nizam_schedule_return_node=node_10000000-0000-0000-0000-000000000002_resume"/>', $artifact->content);

--- a/backend/tests/Feature/FlowCompilerSnapshotTest.php
+++ b/backend/tests/Feature/FlowCompilerSnapshotTest.php
@@ -8,8 +8,6 @@ use App\Models\FlowNode;
 use App\Models\FlowVersion;
 use App\Models\RingGroup;
 use App\Models\Organization;
-use App\Services\Flow\Compile\FlowToIrCompiler;
-use App\Domain\Flow\Compile\NodeSpecRegistry;
 use App\Services\Flow\FlowArtifactService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -26,9 +24,10 @@ class FlowCompilerSnapshotTest extends TestCase
         parent::setUp();
 
         $this->organization = Organization::factory()->create(['domain' => 'snapshot.example.com']);
-        $registry = new NodeSpecRegistry();
-        $compiler = new FlowToIrCompiler($registry);
-        $this->artifactService = new FlowArtifactService($compiler, app(\App\Services\Routing\RoutingGraphCompiler::class));
+        // Resolved from the container rather than hand-constructed: the service
+        // has gained collaborators twice, and each time this line broke with an
+        // ArgumentCountError that had nothing to do with what the test asserts.
+        $this->artifactService = app(FlowArtifactService::class);
     }
 
     public function test_compiled_xml_matches_expected_snapshot(): void

--- a/backend/tests/Feature/FlowPublishServiceTest.php
+++ b/backend/tests/Feature/FlowPublishServiceTest.php
@@ -15,7 +15,9 @@ use Tests\TestCase;
 class FlowPublishServiceTest extends TestCase
 {
     use RefreshDatabase;
+
     protected FlowPublishService $publishService;
+
     protected Organization $organization;
 
     protected function setUp(): void

--- a/backend/tests/Feature/FlowPublishServiceTest.php
+++ b/backend/tests/Feature/FlowPublishServiceTest.php
@@ -8,11 +8,7 @@ use App\Models\FlowNode;
 use App\Models\FlowVersion;
 use App\Models\Organization;
 use App\Models\OrganizationDialplanManifest;
-use App\Services\Flow\FlowArtifactService;
 use App\Services\Flow\FlowPublishService;
-use App\Services\Flow\Compile\FlowToIrCompiler;
-use App\Domain\Flow\Compile\NodeSpecRegistry;
-use App\Services\OrganizationManifestBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -27,12 +23,10 @@ class FlowPublishServiceTest extends TestCase
         parent::setUp();
 
         $this->organization = Organization::factory()->create(['domain' => 'test.example.com']);
-        $registry = new NodeSpecRegistry();
-        $compiler = new FlowToIrCompiler($registry);
-        $artifactService = new FlowArtifactService($compiler, app(\App\Services\Routing\RoutingGraphCompiler::class));
-        $manifestBuilder = new OrganizationManifestBuilder(app(\App\Services\DialplanCompiler::class));
-        $integrityValidator = app(\App\Services\Flow\FlowIntegrityValidator::class);
-        $this->publishService = new FlowPublishService($artifactService, $manifestBuilder, $integrityValidator);
+        // Resolved from the container rather than hand-constructed: these
+        // services have gained collaborators since, and each time this wiring
+        // broke with an ArgumentCountError unrelated to what the test asserts.
+        $this->publishService = app(FlowPublishService::class);
     }
 
     public function test_can_publish_flow_version(): void

--- a/backend/tests/Unit/Models/DidTest.php
+++ b/backend/tests/Unit/Models/DidTest.php
@@ -42,7 +42,7 @@ class DidTest extends TestCase
     public function test_has_correct_fillable_attributes(): void
     {
         $did = new Did;
-        $expected = ['organization_id', 'gateway_id', 'number', 'normalized_number', 'description', 'destination_type', 'destination_id', 'is_active'];
+        $expected = ['organization_id', 'gateway_id', 'number', 'normalized_number', 'description', 'recording_policy', 'destination_type', 'destination_id', 'is_active'];
 
         $this->assertEquals($expected, $did->getFillable());
     }

--- a/backend/tests/Unit/Models/OrganizationTest.php
+++ b/backend/tests/Unit/Models/OrganizationTest.php
@@ -55,6 +55,7 @@ class OrganizationTest extends TestCase
             'max_calls_per_minute',
             'is_active',
             'status',
+            'recording_policy',
         ], $organization->getFillable());
     }
 

--- a/backend/tests/Unit/PermissionRegistryCoverageTest.php
+++ b/backend/tests/Unit/PermissionRegistryCoverageTest.php
@@ -77,8 +77,12 @@ class PermissionRegistryCoverageTest extends TestCase
                     continue;
                 }
 
+                // Deliberately shape-agnostic: an earlier version of this
+                // pattern required a dotted slug and so missed FlowPolicy's
+                // hyphenated `view-flows`, which was exactly the kind of gap
+                // this test exists to catch.
                 preg_match_all(
-                    "/hasPermission\(\s*'([a-z_]+\.[a-z_]+)'\s*\)/",
+                    "/hasPermission\(\s*'([^']+)'\s*\)/",
                     (string) file_get_contents($file->getPathname()),
                     $matches
                 );

--- a/backend/tests/Unit/PermissionRegistryCoverageTest.php
+++ b/backend/tests/Unit/PermissionRegistryCoverageTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\SyncPermissionsCommand;
+use App\Modules\ModuleRegistry;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * Guards the permission registry against silent gaps.
+ *
+ * Permissions are deny-by-default, so a slug that a policy checks but that
+ * `nizam:sync-permissions` cannot create is not a cosmetic omission — the row
+ * never exists, the grant can never be made, and the feature is unreachable for
+ * everyone below admin. `endpoint_bindings.*` sat in exactly that state.
+ */
+class PermissionRegistryCoverageTest extends TestCase
+{
+    public function test_every_permission_a_policy_checks_can_be_created_by_sync(): void
+    {
+        $declared = $this->declaredSlugs();
+        $used = $this->slugsCheckedInCode();
+
+        $missing = array_values(array_diff($used, $declared));
+
+        $this->assertSame([], $missing, sprintf(
+            'These slugs are checked by hasPermission() but are declared nowhere, so no one can be granted them: %s. '
+            .'Add them to SyncPermissionsCommand::$corePermissions or to the owning module\'s permissions().',
+            implode(', ', $missing)
+        ));
+    }
+
+    /**
+     * Every slug the app could create: the core list plus every module's, whether
+     * that module is currently enabled or not.
+     *
+     * @return array<int, string>
+     */
+    private function declaredSlugs(): array
+    {
+        $core = (new ReflectionClass(SyncPermissionsCommand::class))
+            ->newInstanceWithoutConstructor();
+
+        $property = (new ReflectionClass(SyncPermissionsCommand::class))
+            ->getProperty('corePermissions');
+
+        $slugs = array_keys($property->getValue($core));
+
+        foreach (app(ModuleRegistry::class)->all() as $module) {
+            $slugs = array_merge($slugs, $module->permissions());
+        }
+
+        return array_values(array_unique($slugs));
+    }
+
+    /**
+     * Every slug reached through User::hasPermission() in first-party code.
+     *
+     * @return array<int, string>
+     */
+    private function slugsCheckedInCode(): array
+    {
+        $slugs = [];
+
+        foreach ([base_path('app'), base_path('modules')] as $root) {
+            if (! is_dir($root)) {
+                continue;
+            }
+
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($files as $file) {
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                preg_match_all(
+                    "/hasPermission\(\s*'([a-z_]+\.[a-z_]+)'\s*\)/",
+                    (string) file_get_contents($file->getPathname()),
+                    $matches
+                );
+
+                $slugs = array_merge($slugs, $matches[1]);
+            }
+        }
+
+        sort($slugs);
+
+        return array_values(array_unique($slugs));
+    }
+}

--- a/backend/tests/Unit/Policies/PolicyTest.php
+++ b/backend/tests/Unit/Policies/PolicyTest.php
@@ -2,8 +2,9 @@
 
 namespace Tests\Unit\Policies;
 
-use App\Models\Organization;
 use App\Models\Extension;
+use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
 use App\Policies\DeviceProfilePolicy;
 use App\Policies\DidPolicy;
@@ -40,6 +41,9 @@ class PolicyTest extends TestCase
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id, 'role' => 'agent']);
+        // Deny-by-default: an ordinary user needs the permission granted explicitly.
+        Permission::updateOrCreate(['slug' => 'organizations.view'], ['module' => 'core']);
+        $user->grantPermissions(['organizations.view']);
 
         $policy = new OrganizationPolicy;
         $this->assertTrue($policy->view($user, $organization));
@@ -73,6 +77,9 @@ class PolicyTest extends TestCase
             'first_name' => 'John',
             'last_name' => 'Doe',
         ]);
+        // Deny-by-default: an ordinary user needs the permission granted explicitly.
+        Permission::updateOrCreate(['slug' => 'extensions.view'], ['module' => 'core']);
+        $user->grantPermissions(['extensions.view']);
 
         $policy = new ExtensionPolicy;
         $this->assertTrue($policy->view($user, $extension));
@@ -111,6 +118,9 @@ class PolicyTest extends TestCase
             'destination_type' => 'extension',
             'destination_id' => $extension->id,
         ]);
+        // Deny-by-default: an ordinary user needs the permission granted explicitly.
+        Permission::updateOrCreate(['slug' => 'dids.view'], ['module' => 'core']);
+        $user->grantPermissions(['dids.view']);
 
         $policy = new DidPolicy;
         $this->assertTrue($policy->view($user, $did));
@@ -169,6 +179,9 @@ class PolicyTest extends TestCase
             'events' => ['call.created'],
             'secret' => 'test-secret',
         ]);
+        // Deny-by-default: an ordinary user needs the permission granted explicitly.
+        Permission::updateOrCreate(['slug' => 'webhooks.view'], ['module' => 'core']);
+        $user->grantPermissions(['webhooks.view']);
 
         $policy = new WebhookPolicy;
         $this->assertTrue($policy->view($user, $webhook));

--- a/backend/tests/Unit/Policies/ResourcePolicyTest.php
+++ b/backend/tests/Unit/Policies/ResourcePolicyTest.php
@@ -4,9 +4,9 @@ namespace Tests\Unit\Policies;
 
 use App\Models\CallDetailRecord;
 use App\Models\CallEventLog;
+use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\Recording;
-use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -40,9 +40,23 @@ class ResourcePolicyTest extends TestCase
         $this->assertTrue($this->admin->can('viewAny', CallEventLog::class));
     }
 
-    public function test_user_without_permissions_can_view_call_events_default_open(): void
+    public function test_user_without_permissions_cannot_view_call_events(): void
     {
-        $this->assertTrue($this->user->can('viewAny', CallEventLog::class));
+        // Deny-by-default: a user with no grants has no access, unlike the old
+        // allow-by-default rule this test used to encode.
+        $this->assertFalse($this->user->can('viewAny', CallEventLog::class));
+    }
+
+    /**
+     * Paired with the denial above so the grant itself is exercised; a policy
+     * hard-wired to false would otherwise satisfy the negative case alone.
+     */
+    public function test_granted_user_can_view_call_events(): void
+    {
+        Permission::updateOrCreate(['slug' => 'call_events.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['call_events.view']);
+
+        $this->assertTrue($this->user->fresh()->can('viewAny', CallEventLog::class));
     }
 
     public function test_user_with_restricted_permissions_cannot_view_call_events(): void
@@ -70,6 +84,8 @@ class ResourcePolicyTest extends TestCase
 
     public function test_user_can_view_own_organization_recording(): void
     {
+        Permission::updateOrCreate(['slug' => 'recordings.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['recordings.view']);
         $recording = Recording::factory()->create(['organization_id' => $this->organization->id]);
 
         $this->assertTrue($this->user->can('view', $recording));
@@ -85,6 +101,8 @@ class ResourcePolicyTest extends TestCase
 
     public function test_user_can_download_own_organization_recording(): void
     {
+        Permission::updateOrCreate(['slug' => 'recordings.download'], ['module' => 'core']);
+        $this->user->grantPermissions(['recordings.download']);
         $recording = Recording::factory()->create(['organization_id' => $this->organization->id]);
 
         $this->assertTrue($this->user->can('download', $recording));
@@ -92,6 +110,8 @@ class ResourcePolicyTest extends TestCase
 
     public function test_user_can_delete_own_organization_recording(): void
     {
+        Permission::updateOrCreate(['slug' => 'recordings.delete'], ['module' => 'core']);
+        $this->user->grantPermissions(['recordings.delete']);
         $recording = Recording::factory()->create(['organization_id' => $this->organization->id]);
 
         $this->assertTrue($this->user->can('delete', $recording));
@@ -104,6 +124,8 @@ class ResourcePolicyTest extends TestCase
 
     public function test_user_can_view_own_organization_cdr(): void
     {
+        Permission::updateOrCreate(['slug' => 'cdrs.view'], ['module' => 'core']);
+        $this->user->grantPermissions(['cdrs.view']);
         $cdr = CallDetailRecord::factory()->create(['organization_id' => $this->organization->id]);
 
         $this->assertTrue($this->user->can('view', $cdr));

--- a/backend/tests/Unit/Policies/Spec3PoliciesTest.php
+++ b/backend/tests/Unit/Policies/Spec3PoliciesTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Unit\Policies;
 
-use App\Models\Flow;
 use App\Models\CallRoutingPolicy;
+use App\Models\Flow;
 use App\Models\Organization;
+use App\Models\Permission;
 use App\Models\User;
-use App\Policies\FlowPolicy;
 use App\Policies\CallRoutingPolicyPolicy;
+use App\Policies\FlowPolicy;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -37,7 +38,7 @@ class Spec3PoliciesTest extends TestCase
         $this->assertTrue($policy->before($admin, 'delete'));
     }
 
-    public function test_organization_user_can_view_own_call_routing_policies(): void
+    public function test_organization_user_without_permission_cannot_view_own_call_routing_policies(): void
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id]);
@@ -45,8 +46,27 @@ class Spec3PoliciesTest extends TestCase
 
         $policy = new CallRoutingPolicyPolicy;
 
-        // Without explicit permission, hasPermission returns true (default-open)
-        $this->assertTrue($policy->view($user, $crp));
+        // Deny-by-default: being in the right organization is not enough without
+        // the call_routing_policies.view grant. This used to pass on the removed
+        // default-open fallback.
+        $this->assertFalse($policy->view($user, $crp));
+    }
+
+    /**
+     * The positive counterpart: with the grant, an organization member does get
+     * access. Asserting only the denial would leave the permission itself
+     * untested — a policy that returned false unconditionally would still pass.
+     */
+    public function test_granted_organization_user_can_view_own_call_routing_policies(): void
+    {
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create(['organization_id' => $organization->id]);
+        $crp = CallRoutingPolicy::factory()->create(['organization_id' => $organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'call_routing_policies.view'], ['module' => 'core']);
+        $user->grantPermissions(['call_routing_policies.view']);
+
+        $this->assertTrue((new CallRoutingPolicyPolicy)->view($user->fresh(), $crp));
     }
 
     public function test_organization_user_cannot_view_other_organizations_policy(): void
@@ -61,7 +81,7 @@ class Spec3PoliciesTest extends TestCase
         $this->assertFalse($policy->view($user, $crp));
     }
 
-    public function test_organization_user_can_view_own_call_flows(): void
+    public function test_organization_user_without_permission_cannot_view_own_call_flows(): void
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id]);
@@ -69,7 +89,21 @@ class Spec3PoliciesTest extends TestCase
 
         $policy = new FlowPolicy;
 
-        $this->assertTrue($policy->view($user, $flow));
+        // Deny-by-default: same reasoning as the call-routing-policy case above —
+        // organization match alone no longer grants view access.
+        $this->assertFalse($policy->view($user, $flow));
+    }
+
+    public function test_granted_organization_user_can_view_own_call_flows(): void
+    {
+        $organization = Organization::factory()->create();
+        $user = User::factory()->create(['organization_id' => $organization->id]);
+        $flow = Flow::factory()->create(['organization_id' => $organization->id]);
+
+        Permission::updateOrCreate(['slug' => 'flows.view'], ['module' => 'core']);
+        $user->grantPermissions(['flows.view']);
+
+        $this->assertTrue((new FlowPolicy)->view($user->fresh(), $flow));
     }
 
     public function test_organization_user_cannot_view_other_organizations_flow(): void

--- a/backend/tests/Unit/Services/EventProcessorEventLogTest.php
+++ b/backend/tests/Unit/Services/EventProcessorEventLogTest.php
@@ -10,9 +10,7 @@ use App\Models\Did;
 use App\Models\EndpointBinding;
 use App\Models\Extension;
 use App\Models\Organization;
-use App\Services\Call\CallOfferExecutor;
 use App\Services\Call\CallWinnerService;
-use App\Services\Call\ReachabilityCache;
 use App\Services\Call\TraceWriter;
 use App\Services\EventProcessor;
 use App\Services\Media\FreeSwitchCommandService;
@@ -55,6 +53,23 @@ class EventProcessorEventLogTest extends TestCase
         ]);
 
         return [$organization, $extension];
+    }
+
+    /**
+     * traceEvents() is a shared call-trace log: CallEventIngestionService also
+     * dispatches a synchronous ProcessCallEventJob for every CHANNEL_ANSWER (see
+     * CallEventProcessor::process), which appends its own unrelated
+     * "call.event.processed" entry regardless of recording/winner outcome. Scope
+     * to recording.* actions so recording-flow assertions aren't tripped by that
+     * unrelated bookkeeping.
+     */
+    private function recordingTraceActions(CallSession $session): array
+    {
+        return $session->traceEvents()
+            ->orderBy('created_at')
+            ->where('action', 'like', 'recording.%')
+            ->pluck('action')
+            ->all();
     }
 
     public function test_channel_create_persists_call_event(): void
@@ -413,12 +428,11 @@ class EventProcessorEventLogTest extends TestCase
         $this->assertSame('did', data_get($session->variables, 'recording_policy_resolution.winning_scope'));
         $this->assertNotNull(data_get($session->variables, 'recording_path'));
 
-        $traceActions = $session->traceEvents()->orderBy('created_at')->pluck('action')->all();
         $this->assertSame([
             'recording.policy.resolved',
             'recording.start.requested',
             'recording.start.succeeded',
-        ], $traceActions);
+        ], $this->recordingTraceActions($session));
     }
 
     public function test_duplicate_channel_answer_for_winner_does_not_repeat_recording_flow(): void
@@ -507,7 +521,7 @@ class EventProcessorEventLogTest extends TestCase
         $this->assertSame(CallDeliveryAttempt::STATUS_WON, $attempt->status);
         $this->assertTrue((bool) data_get($session->variables, 'recording_started'));
         $this->assertSame(storage_path('app/recordings/'.$organization->id.'/caller-leg-duplicate-answer.wav'), data_get($session->variables, 'recording_path'));
-        $this->assertCount(0, $session->traceEvents()->get());
+        $this->assertCount(0, $this->recordingTraceActions($session));
     }
 
     public function test_duplicate_channel_answer_with_existing_disabled_resolution_does_not_repeat_trace_flow(): void
@@ -596,7 +610,7 @@ class EventProcessorEventLogTest extends TestCase
 
         $this->assertSame(CallDeliveryAttempt::STATUS_WON, $attempt->status);
         $this->assertFalse((bool) data_get($session->variables, 'recording_policy_resolution.should_record'));
-        $this->assertCount(0, $session->traceEvents()->get());
+        $this->assertCount(0, $this->recordingTraceActions($session));
     }
 
     public function test_channel_answer_for_non_winner_does_not_start_recording(): void
@@ -668,7 +682,7 @@ class EventProcessorEventLogTest extends TestCase
         $this->assertSame(CallDeliveryAttempt::STATUS_ANSWERED, $attempt->status);
         $this->assertNull(data_get($session->variables, 'recording_started'));
         $this->assertNull(data_get($session->variables, 'recording_policy_resolution'));
-        $this->assertCount(0, $session->traceEvents()->get());
+        $this->assertCount(0, $this->recordingTraceActions($session));
     }
 
     public function test_channel_bridge_persists_orchestrated_bridge_metadata(): void

--- a/backend/tests/Unit/Services/PresenceAggregatorTest.php
+++ b/backend/tests/Unit/Services/PresenceAggregatorTest.php
@@ -35,15 +35,16 @@ class PresenceAggregatorTest extends TestCase
     {
         $organization = Organization::factory()->create();
         $user = User::factory()->create(['organization_id' => $organization->id]);
+        // Extensions are one-per-user per organization (see the unique
+        // constraint added in 2026_04_22_020000_add_device_owner_to_extensions_table
+        // and the matching validation in StoreExtensionRequest). A user can
+        // still have several devices registered against their single
+        // extension, so the "secondary" device below hangs off the same
+        // primary extension instead of a second owned extension.
         $primaryExtension = Extension::factory()->create([
             'organization_id' => $organization->id,
             'user_id' => $user->id,
             'is_primary' => true,
-        ]);
-        $secondaryExtension = Extension::factory()->create([
-            'organization_id' => $organization->id,
-            'user_id' => $user->id,
-            'is_primary' => false,
         ]);
 
         $directDevice = DeviceProfile::factory()->create([
@@ -61,7 +62,7 @@ class PresenceAggregatorTest extends TestCase
         DeviceProfile::factory()->create([
             'organization_id' => $organization->id,
             'user_id' => null,
-            'extension_id' => $secondaryExtension->id,
+            'extension_id' => $primaryExtension->id,
             'is_active' => false,
         ]);
 

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -34,6 +34,7 @@ const FlowsPage = lazy(() => import('@/pages/admin/FlowsPage'));
 const FlowEditorPage = lazy(() => import('@/pages/admin/FlowEditorPage'));
 const SystemMediaPage = lazy(() => import('@/pages/admin/SystemMediaPage'));
 const CallHistoryPage = lazy(() => import('@/pages/admin/CallHistoryPage'));
+const RecordingsPage = lazy(() => import('@/pages/admin/RecordingsPage'));
 const InteractionDetailPage = lazy(() => import('@/pages/admin/InteractionDetailPage'));
 const AuditLogsPage = lazy(() => import('@/pages/admin/AuditLogsPage'));
 const LogViewerPage = lazy(() => import('@/pages/admin/LogViewerPage'));
@@ -185,6 +186,7 @@ const router = createBrowserRouter(
 
                 {/* Call History (organization-scoped) */}
                 <Route path="call-history" element={<CallHistoryPage />} />
+                <Route path="recordings" element={<RecordingsPage />} />
                 <Route path="call-blocks" element={<CallBlocksPage />} />
                 <Route path="interactions/:id" element={<InteractionDetailPage />} />
 

--- a/frontend/src/components/admin/RecordingPlayer.tsx
+++ b/frontend/src/components/admin/RecordingPlayer.tsx
@@ -1,0 +1,106 @@
+import { AlertCircle, Loader2, Play } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { fetchRecordingObjectUrl, revokeObjectUrl } from '@/lib/media';
+import { getErrorMessage } from '@/lib/api-hooks';
+
+interface RecordingPlayerProps {
+    /** Organization-scoped download URL, e.g. `organizations/x/recordings/y/download`. */
+    downloadUrl: string;
+    /** Stored format, used to pick a MIME type the browser will decode. */
+    format?: string | null;
+    /** Rendered compactly for use inside a table row. */
+    compact?: boolean;
+}
+
+/**
+ * Plays a call recording inline.
+ *
+ * Audio is fetched lazily on first play rather than on mount: a call-history or
+ * recordings page can show dozens of rows, and eagerly pulling every file would
+ * be wasteful. Until then the control is just a play button.
+ */
+export function RecordingPlayer({ downloadUrl, format, compact = false }: RecordingPlayerProps) {
+    const [objectUrl, setObjectUrl] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+
+    // Revoke the blob when this row unmounts or the target changes, otherwise
+    // paging through a long list leaks every file that was played.
+    useEffect(() => {
+        return () => revokeObjectUrl(objectUrl);
+    }, [objectUrl]);
+
+    useEffect(() => {
+        setObjectUrl(null);
+        setError(null);
+    }, [downloadUrl]);
+
+    const load = async () => {
+        if (objectUrl || isLoading) return;
+
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const url = await fetchRecordingObjectUrl(downloadUrl, format);
+            setObjectUrl(url);
+        } catch (caught) {
+            setError(getErrorMessage(caught));
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    // Autoplay once the blob resolves, so one click means "play" rather than
+    // "load, then click again".
+    useEffect(() => {
+        if (objectUrl && audioRef.current) {
+            void audioRef.current.play().catch(() => {
+                // Autoplay can be blocked by the browser; the visible controls
+                // still work, so there is nothing to recover from here.
+            });
+        }
+    }, [objectUrl]);
+
+    if (error) {
+        return (
+            <span className="inline-flex items-center gap-1.5 text-xs text-destructive" title={error}>
+                <AlertCircle className="size-3.5 shrink-0" />
+                {compact ? 'Unavailable' : error}
+            </span>
+        );
+    }
+
+    if (objectUrl) {
+        return (
+            <audio
+                ref={audioRef}
+                src={objectUrl}
+                controls
+                preload="auto"
+                className={compact ? 'h-8 w-[220px]' : 'h-9 w-full'}
+            />
+        );
+    }
+
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            onClick={load}
+            disabled={isLoading}
+            className="h-8"
+            aria-label="Play recording"
+        >
+            {isLoading ? (
+                <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+                <Play className="size-3.5" />
+            )}
+            {compact ? null : <span className="ml-1.5">Play</span>}
+        </Button>
+    );
+}

--- a/frontend/src/components/admin/RecordingPlayer.tsx
+++ b/frontend/src/components/admin/RecordingPlayer.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Loader2, Play } from 'lucide-react';
+import { AlertCircle, Loader2, Play, RotateCcw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -26,6 +26,14 @@ export function RecordingPlayer({ downloadUrl, format, compact = false }: Record
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const audioRef = useRef<HTMLAudioElement | null>(null);
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+        };
+    }, []);
 
     // Revoke the blob when this row unmounts or the target changes, otherwise
     // paging through a long list leaks every file that was played.
@@ -46,11 +54,25 @@ export function RecordingPlayer({ downloadUrl, format, compact = false }: Record
 
         try {
             const url = await fetchRecordingObjectUrl(downloadUrl, format);
+
+            // A row can be unmounted while its audio is still in flight — paging
+            // away mid-download. The blob is already allocated at this point, so
+            // it has to be released here; the revoke effect above will never run
+            // for a URL that was never committed to state.
+            if (!isMountedRef.current) {
+                revokeObjectUrl(url);
+                return;
+            }
+
             setObjectUrl(url);
         } catch (caught) {
-            setError(getErrorMessage(caught));
+            if (isMountedRef.current) {
+                setError(getErrorMessage(caught));
+            }
         } finally {
-            setIsLoading(false);
+            if (isMountedRef.current) {
+                setIsLoading(false);
+            }
         }
     };
 
@@ -66,11 +88,30 @@ export function RecordingPlayer({ downloadUrl, format, compact = false }: Record
     }, [objectUrl]);
 
     if (error) {
+        // A failed fetch is usually transient (expired token, network blip), so
+        // the control stays actionable instead of becoming dead text.
         return (
-            <span className="inline-flex items-center gap-1.5 text-xs text-destructive" title={error}>
-                <AlertCircle className="size-3.5 shrink-0" />
-                {compact ? 'Unavailable' : error}
-            </span>
+            <div className="inline-flex items-center gap-1.5">
+                <span
+                    className="inline-flex items-center gap-1.5 text-xs text-destructive"
+                    title={error}
+                >
+                    <AlertCircle className="size-3.5 shrink-0" />
+                    {compact ? 'Unavailable' : error}
+                </span>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={() => {
+                        setError(null);
+                        void load();
+                    }}
+                    aria-label="Retry loading recording"
+                >
+                    <RotateCcw className="size-3.5" />
+                </Button>
+            </div>
         );
     }
 
@@ -90,7 +131,7 @@ export function RecordingPlayer({ downloadUrl, format, compact = false }: Record
         <Button
             variant="outline"
             size="sm"
-            onClick={load}
+            onClick={() => void load()}
             disabled={isLoading}
             className="h-8"
             aria-label="Play recording"

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,60 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import type { PaginationMeta } from '@/types/models';
+
+interface PaginationProps {
+    meta?: PaginationMeta | null;
+    onPageChange: (page: number) => void;
+    /** Noun for the row count, e.g. "calls" or "recordings". */
+    itemLabel?: string;
+}
+
+/**
+ * Prev/next pager driven by Laravel paginator metadata.
+ *
+ * Renders the real total rather than the loaded row count — several pages
+ * previously derived their stat tiles from a single page of results and reported
+ * numbers that silently capped at the page size.
+ */
+export function Pagination({ meta, onPageChange, itemLabel = 'results' }: PaginationProps) {
+    if (!meta || meta.total === 0) {
+        return null;
+    }
+
+    const { current_page: current, last_page: last, from, to, total } = meta;
+
+    return (
+        <div className="flex flex-col gap-3 border-t px-1 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+                Showing <span className="font-medium text-foreground">{from ?? 0}</span>–
+                <span className="font-medium text-foreground">{to ?? 0}</span> of{' '}
+                <span className="font-medium text-foreground">{total.toLocaleString()}</span> {itemLabel}
+            </p>
+
+            <div className="flex items-center gap-2">
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(current - 1)}
+                    disabled={current <= 1}
+                >
+                    <ChevronLeft className="size-4" />
+                    Previous
+                </Button>
+                <span className="px-1 text-sm text-muted-foreground">
+                    Page {current} of {last}
+                </span>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onPageChange(current + 1)}
+                    disabled={current >= last}
+                >
+                    Next
+                    <ChevronRight className="size-4" />
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/ui/table-pagination.tsx
+++ b/frontend/src/components/ui/table-pagination.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { PaginationMeta } from '@/types/models';
 
-interface PaginationProps {
+interface TablePaginationProps {
     meta?: PaginationMeta | null;
     onPageChange: (page: number) => void;
     /** Noun for the row count, e.g. "calls" or "recordings". */
@@ -17,7 +17,7 @@ interface PaginationProps {
  * previously derived their stat tiles from a single page of results and reported
  * numbers that silently capped at the page size.
  */
-export function Pagination({ meta, onPageChange, itemLabel = 'results' }: PaginationProps) {
+export function TablePagination({ meta, onPageChange, itemLabel = 'results' }: TablePaginationProps) {
     if (!meta || meta.total === 0) {
         return null;
     }

--- a/frontend/src/layouts/SuperadminLayout.tsx
+++ b/frontend/src/layouts/SuperadminLayout.tsx
@@ -5,6 +5,7 @@ import {
     ChevronLeft,
     ChevronRight,
     ChevronsUpDown,
+    FileAudio,
     FileText,
     Globe,
     Hash,
@@ -95,6 +96,7 @@ const NAV_SECTIONS: NavSection[] = [
         title: 'Calls',
         items: [
             { label: 'Call History', icon: PhoneCall, href: '/admin/call-history', organizationRequired: true },
+            { label: 'Recordings', icon: FileAudio, href: '/admin/recordings', organizationRequired: true },
         ],
     },
     {

--- a/frontend/src/lib/media.ts
+++ b/frontend/src/lib/media.ts
@@ -1,0 +1,117 @@
+import api from '@/lib/api';
+
+/**
+ * Helpers for fetching authenticated binary responses.
+ *
+ * Recording downloads and CDR exports both sit behind Sanctum bearer auth and
+ * are served as attachments, so neither can be pointed at directly from an
+ * `<audio src>` or an `<a href>` — the browser would send no Authorization
+ * header. Everything here goes through the shared axios client (which attaches
+ * the token) and turns the response into an object URL or a save prompt.
+ */
+
+/** Map a stored recording format to a MIME type a browser will play. */
+function audioMimeType(format?: string | null): string {
+    switch ((format ?? '').toLowerCase()) {
+        case 'mp3':
+            return 'audio/mpeg';
+        case 'ogg':
+        case 'opus':
+            return 'audio/ogg';
+        case 'm4a':
+        case 'mp4':
+            return 'audio/mp4';
+        case 'wav':
+        default:
+            // FreeSWITCH records WAV by default. Guessing wav for unknown
+            // formats is safer than passing through an octet-stream type, which
+            // some browsers refuse to decode.
+            return 'audio/wav';
+    }
+}
+
+/**
+ * Fetch a recording and return a playable object URL.
+ *
+ * The whole file is pulled into memory rather than streamed. Call recordings are
+ * small enough that this is a fair trade for not needing a separate unauthenticated
+ * streaming endpoint, and it makes seeking work without range requests.
+ *
+ * The caller owns the returned URL and must revoke it (see `revokeObjectUrl`).
+ */
+export async function fetchRecordingObjectUrl(
+    url: string,
+    format?: string | null,
+): Promise<string> {
+    const response = await api.get<Blob>(url, { responseType: 'blob' });
+
+    return URL.createObjectURL(
+        new Blob([response.data], { type: audioMimeType(format) }),
+    );
+}
+
+export function revokeObjectUrl(url: string | null): void {
+    if (url) {
+        URL.revokeObjectURL(url);
+    }
+}
+
+/**
+ * Fetch a binary endpoint and prompt the browser to save it.
+ *
+ * Used for recording downloads and CSV exports. Any filename the server sent in
+ * Content-Disposition is ignored in favour of the caller's, since the export
+ * endpoint's generated name is not meaningful to a user.
+ */
+export async function downloadAuthenticatedFile(
+    url: string,
+    filename: string,
+    params?: Record<string, unknown>,
+): Promise<void> {
+    const response = await api.get<Blob>(url, { responseType: 'blob', params });
+    const objectUrl = URL.createObjectURL(response.data);
+
+    try {
+        const anchor = document.createElement('a');
+        anchor.href = objectUrl;
+        anchor.download = filename;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+    } finally {
+        URL.revokeObjectURL(objectUrl);
+    }
+}
+
+/** Format a byte count for display, e.g. 2.4 MB. */
+export function formatFileSize(bytes?: number | null): string {
+    if (bytes === null || bytes === undefined) return '—';
+    if (bytes < 1024) return `${bytes} B`;
+
+    const units = ['KB', 'MB', 'GB'];
+    let value = bytes / 1024;
+    let unitIndex = 0;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex += 1;
+    }
+
+    return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+/** Format a duration in seconds as m:ss, or h:mm:ss past an hour. */
+export function formatDuration(seconds?: number | null): string {
+    if (seconds === null || seconds === undefined) return '—';
+
+    const total = Math.max(0, Math.round(seconds));
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    const secs = total % 60;
+
+    if (hours > 0) {
+        return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+    }
+
+    return `${minutes}:${String(secs).padStart(2, '0')}`;
+}

--- a/frontend/src/pages/admin/CallHistoryPage.tsx
+++ b/frontend/src/pages/admin/CallHistoryPage.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Pagination } from '@/components/ui/pagination';
+import { TablePagination } from '@/components/ui/table-pagination';
 import {
     Select,
     SelectContent,
@@ -38,7 +38,7 @@ import {
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
 import { downloadAuthenticatedFile, formatDuration } from '@/lib/media';
-import type { Cdr, CdrSummary, PaginationMeta } from '@/types/models';
+import type { Cdr, CdrPaginationMeta } from '@/types/models';
 
 interface Filters {
     search: string;
@@ -72,14 +72,33 @@ function formatDateTime(value?: string | null): string {
     return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
-function directionIcon(direction?: string | null) {
+/**
+ * Direction is shown as an icon to keep the row narrow, so the label it stands
+ * for is exposed to assistive technology rather than living only in a tooltip.
+ */
+function DirectionIcon({ direction }: { direction?: string | null }) {
     switch (direction?.toLowerCase()) {
         case 'inbound':
-            return <PhoneIncoming className="size-4 text-emerald-600" />;
+            return (
+                <>
+                    <PhoneIncoming className="size-4 text-emerald-600" />
+                    <span className="sr-only">Inbound call</span>
+                </>
+            );
         case 'outbound':
-            return <PhoneOutgoing className="size-4 text-blue-600" />;
+            return (
+                <>
+                    <PhoneOutgoing className="size-4 text-blue-600" />
+                    <span className="sr-only">Outbound call</span>
+                </>
+            );
         default:
-            return <PhoneCall className="size-4 text-muted-foreground" />;
+            return (
+                <>
+                    <PhoneCall className="size-4 text-muted-foreground" />
+                    <span className="sr-only">Unknown direction</span>
+                </>
+            );
     }
 }
 
@@ -140,7 +159,7 @@ export default function CallHistoryPage() {
     const { data, isLoading, isError } = useQuery({
         queryKey: ['cdrs', activeOrganization?.id, applied, page],
         queryFn: async () => {
-            const response = await api.get<{ data: Cdr[]; meta?: PaginationMeta }>(
+            const response = await api.get<{ data: Cdr[]; meta?: CdrPaginationMeta }>(
                 `${organizationApiPrefix}/cdrs`,
                 { params: { ...params, page } },
             );
@@ -149,19 +168,10 @@ export default function CallHistoryPage() {
         enabled: Boolean(activeOrganization),
     });
 
-    // Counters come from the server-side aggregate rather than the current page,
-    // which is why they can exceed the page size.
-    const { data: summary } = useQuery({
-        queryKey: ['cdr-summary', activeOrganization?.id, applied],
-        queryFn: async () => {
-            const response = await api.get<{ data: CdrSummary }>(
-                `${organizationApiPrefix}/cdrs/analytics/summary`,
-                { params: { date_from: params.date_from, date_to: params.date_to } },
-            );
-            return response.data.data;
-        },
-        enabled: Boolean(activeOrganization),
-    });
+    // Counters ride along in the list response's meta, so they are aggregated
+    // over every call matching the current filters — not just the loaded page,
+    // and not a differently-filtered set from a separate analytics call.
+    const summary = data?.meta?.summary;
 
     const applyFilters = () => {
         setApplied(draft);
@@ -228,7 +238,9 @@ export default function CallHistoryPage() {
                             {summary ? summary.answered_calls.toLocaleString() : '—'}
                         </div>
                         {summary ? (
-                            <p className="text-xs text-muted-foreground">{summary.asr}% answer rate</p>
+                            <p className="text-xs text-muted-foreground">
+                                {summary.asr.toFixed(1)}% answer rate
+                            </p>
                         ) : null}
                     </CardContent>
                 </Card>
@@ -335,7 +347,9 @@ export default function CallHistoryPage() {
                     <Table>
                         <TableHeader>
                             <TableRow>
-                                <TableHead className="w-10" />
+                                <TableHead className="w-10">
+                                    <span className="sr-only">Direction</span>
+                                </TableHead>
                                 <TableHead>From</TableHead>
                                 <TableHead>To</TableHead>
                                 <TableHead>Started</TableHead>
@@ -375,8 +389,8 @@ export default function CallHistoryPage() {
 
                                     return (
                                         <TableRow key={cdr.id}>
-                                            <TableCell title={cdr.direction ?? 'Unknown direction'}>
-                                                {directionIcon(cdr.direction)}
+                                            <TableCell>
+                                                <DirectionIcon direction={cdr.direction} />
                                             </TableCell>
                                             <TableCell>
                                                 <div className="font-mono text-sm">
@@ -450,7 +464,7 @@ export default function CallHistoryPage() {
                         </TableBody>
                     </Table>
 
-                    <Pagination meta={data?.meta} onPageChange={setPage} itemLabel="calls" />
+                    <TablePagination meta={data?.meta} onPageChange={setPage} itemLabel="calls" />
                 </CardContent>
             </Card>
         </div>

--- a/frontend/src/pages/admin/CallHistoryPage.tsx
+++ b/frontend/src/pages/admin/CallHistoryPage.tsx
@@ -364,7 +364,13 @@ export default function CallHistoryPage() {
                             {isLoading ? (
                                 <TableRow>
                                     <TableCell colSpan={9} className="py-10 text-center">
-                                        <div className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                                        <div role="status">
+                                            <div
+                                                className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent"
+                                                aria-hidden="true"
+                                            />
+                                            <span className="sr-only">Loading call history…</span>
+                                        </div>
                                     </TableCell>
                                 </TableRow>
                             ) : isError ? (

--- a/frontend/src/pages/admin/CallHistoryPage.tsx
+++ b/frontend/src/pages/admin/CallHistoryPage.tsx
@@ -1,26 +1,32 @@
 import { useQuery } from '@tanstack/react-query';
 import {
     ArrowRight,
-    CheckCircle2,
-    Clock3,
-    History,
+    Download,
     PhoneCall,
     PhoneIncoming,
     PhoneOutgoing,
-    Route,
+    Search,
+    X,
 } from 'lucide-react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 
+import { RecordingPlayer } from '@/components/admin/RecordingPlayer';
 import { PageHeader } from '@/components/scaffolds/PageHeader';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Pagination } from '@/components/ui/pagination';
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import {
     Table,
     TableBody,
@@ -31,37 +37,42 @@ import {
 } from '@/components/ui/table';
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
-import type { CallSessionSummary } from '@/types/models';
+import { downloadAuthenticatedFile, formatDuration } from '@/lib/media';
+import type { Cdr, CdrSummary, PaginationMeta } from '@/types/models';
 
-function formatDateTime(value: string | null | undefined): string {
+interface Filters {
+    search: string;
+    direction: string;
+    date_from: string;
+    date_to: string;
+}
+
+const EMPTY_FILTERS: Filters = {
+    search: '',
+    direction: 'any',
+    date_from: '',
+    date_to: '',
+};
+
+/** Strip UI-only sentinels before sending filters to the API. */
+function toQueryParams(filters: Filters): Record<string, string> {
+    const params: Record<string, string> = {};
+
+    if (filters.search) params.search = filters.search;
+    if (filters.direction && filters.direction !== 'any') params.direction = filters.direction;
+    if (filters.date_from) params.date_from = filters.date_from;
+    if (filters.date_to) params.date_to = filters.date_to;
+
+    return params;
+}
+
+function formatDateTime(value?: string | null): string {
     if (!value) return '—';
-
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
-function formatStatus(value: string | null | undefined): string {
-    if (!value) return 'Unknown';
-
-    return value
-        .replace(/[._]/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function statusVariant(value: string | null | undefined): 'success' | 'warning' | 'destructive' | 'secondary' {
-    const normalized = value?.toLowerCase();
-
-    if (!normalized) return 'secondary';
-    if (['bridged', 'completed', 'won', 'answered', 'success'].includes(normalized)) return 'success';
-    if (['failed', 'error', 'missed', 'abandoned'].includes(normalized)) return 'destructive';
-    if (['pending', 'ringing', 'queued', 'processing'].includes(normalized)) return 'warning';
-
-    return 'secondary';
-}
-
-function directionIcon(direction: string | null | undefined) {
+function directionIcon(direction?: string | null) {
     switch (direction?.toLowerCase()) {
         case 'inbound':
             return <PhoneIncoming className="size-4 text-emerald-600" />;
@@ -72,46 +83,128 @@ function directionIcon(direction: string | null | undefined) {
     }
 }
 
-function sessionOutcome(session: CallSessionSummary): string {
-    const winningAttempt = session.winner?.attempt;
-
-    if (!winningAttempt) {
-        return 'No winner recorded';
+/**
+ * Translate a FreeSWITCH hangup cause into something a phone-system admin can
+ * act on. The raw causes are SIP-flavoured and mean little to most operators.
+ */
+function describeResult(cdr: Cdr): { label: string; variant: 'success' | 'warning' | 'destructive' | 'secondary' } {
+    if (cdr.answer_stamp) {
+        return { label: 'Answered', variant: 'success' };
     }
 
-    const channel = [winningAttempt.endpoint?.platform, winningAttempt.endpoint?.type]
-        .filter(Boolean)
-        .join(' ')
-        .trim();
+    switch ((cdr.hangup_cause ?? '').toUpperCase()) {
+        case 'NO_ANSWER':
+        case 'ALLOTTED_TIMEOUT':
+            return { label: 'No answer', variant: 'warning' };
+        case 'USER_BUSY':
+            return { label: 'Busy', variant: 'warning' };
+        case 'ORIGINATOR_CANCEL':
+            return { label: 'Caller hung up', variant: 'secondary' };
+        case 'CALL_REJECTED':
+            return { label: 'Rejected', variant: 'destructive' };
+        case 'UNALLOCATED_NUMBER':
+            return { label: 'No such number', variant: 'destructive' };
+        case 'NO_ROUTE_DESTINATION':
+            return { label: 'No route', variant: 'destructive' };
+        case 'NORMAL_CLEARING':
+            return { label: 'Not answered', variant: 'secondary' };
+        case '':
+            return { label: 'Unknown', variant: 'secondary' };
+        default:
+            return { label: 'Failed', variant: 'destructive' };
+    }
+}
 
-    return channel ? `${formatStatus(winningAttempt.attempt_type)} via ${formatStatus(channel)}` : formatStatus(winningAttempt.attempt_type);
+/** Ring time is the gap between the call starting and being answered. */
+function ringSeconds(cdr: Cdr): number | null {
+    if (!cdr.start_stamp || !cdr.answer_stamp) return null;
+
+    const start = new Date(cdr.start_stamp).getTime();
+    const answer = new Date(cdr.answer_stamp).getTime();
+
+    if (Number.isNaN(start) || Number.isNaN(answer)) return null;
+
+    return Math.max(0, Math.round((answer - start) / 1000));
 }
 
 export default function CallHistoryPage() {
     const { activeOrganization, organizationApiPrefix } = useOrganization();
 
-    const { data: sessions = [], isLoading } = useQuery({
-        queryKey: ['calls', activeOrganization?.id],
+    const [draft, setDraft] = useState<Filters>(EMPTY_FILTERS);
+    const [applied, setApplied] = useState<Filters>(EMPTY_FILTERS);
+    const [page, setPage] = useState(1);
+    const [isExporting, setIsExporting] = useState(false);
+
+    const params = toQueryParams(applied);
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['cdrs', activeOrganization?.id, applied, page],
         queryFn: async () => {
-            const response = await api.get<{ data: CallSessionSummary[] }>(`${organizationApiPrefix}/calls`);
+            const response = await api.get<{ data: Cdr[]; meta?: PaginationMeta }>(
+                `${organizationApiPrefix}/cdrs`,
+                { params: { ...params, page } },
+            );
+            return response.data;
+        },
+        enabled: Boolean(activeOrganization),
+    });
+
+    // Counters come from the server-side aggregate rather than the current page,
+    // which is why they can exceed the page size.
+    const { data: summary } = useQuery({
+        queryKey: ['cdr-summary', activeOrganization?.id, applied],
+        queryFn: async () => {
+            const response = await api.get<{ data: CdrSummary }>(
+                `${organizationApiPrefix}/cdrs/analytics/summary`,
+                { params: { date_from: params.date_from, date_to: params.date_to } },
+            );
             return response.data.data;
         },
         enabled: Boolean(activeOrganization),
     });
 
+    const applyFilters = () => {
+        setApplied(draft);
+        setPage(1);
+    };
+
+    const clearFilters = () => {
+        setDraft(EMPTY_FILTERS);
+        setApplied(EMPTY_FILTERS);
+        setPage(1);
+    };
+
+    const exportCsv = async () => {
+        setIsExporting(true);
+        try {
+            await downloadAuthenticatedFile(
+                `${organizationApiPrefix}/cdrs/export`,
+                `call-history-${new Date().toISOString().slice(0, 10)}.csv`,
+                { ...params, format: 'csv' },
+            );
+        } catch {
+            toast.error('Could not export call history.');
+        } finally {
+            setIsExporting(false);
+        }
+    };
+
     if (!activeOrganization) {
         return (
             <div className="flex h-64 items-center justify-center text-muted-foreground">
-                Select a organization to view call history.
+                Select an organization to view call history.
             </div>
         );
     }
+
+    const cdrs = data?.data ?? [];
+    const hasFilters = Object.keys(params).length > 0;
 
     return (
         <div className="space-y-6 p-6 lg:p-8">
             <PageHeader
                 title="Call History"
-                description="Unified view of all calls and their interaction journeys."
+                description="Every call in and out of this organization, with recordings where available."
                 breadcrumbs={`${activeOrganization.name} › Calls`}
             />
 
@@ -121,7 +214,9 @@ export default function CallHistoryPage() {
                         <CardTitle className="text-sm font-medium text-muted-foreground">Total Calls</CardTitle>
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">{sessions.length}</div>
+                        <div className="text-2xl font-bold">
+                            {summary ? summary.total_calls.toLocaleString() : '—'}
+                        </div>
                     </CardContent>
                 </Card>
                 <Card>
@@ -130,8 +225,11 @@ export default function CallHistoryPage() {
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold text-emerald-600">
-                            {sessions.filter((s) => s.winner?.attempt_id).length}
+                            {summary ? summary.answered_calls.toLocaleString() : '—'}
                         </div>
+                        {summary ? (
+                            <p className="text-xs text-muted-foreground">{summary.asr}% answer rate</p>
+                        ) : null}
                     </CardContent>
                 </Card>
                 <Card>
@@ -139,104 +237,220 @@ export default function CallHistoryPage() {
                         <CardTitle className="text-sm font-medium text-muted-foreground">Missed</CardTitle>
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold text-destructive">
-                            {sessions.filter((s) => s.state === 'missed').length}
+                        <div className="text-2xl font-bold text-amber-600">
+                            {summary ? summary.missed_calls.toLocaleString() : '—'}
                         </div>
                     </CardContent>
                 </Card>
                 <Card>
                     <CardHeader className="pb-2">
-                        <CardTitle className="text-sm font-medium text-muted-foreground">Latest Activity</CardTitle>
+                        <CardTitle className="text-sm font-medium text-muted-foreground">
+                            Avg talk time
+                        </CardTitle>
                     </CardHeader>
                     <CardContent>
-                        <div className="text-sm font-medium">
-                            {formatDateTime(sessions[0]?.started_at ?? sessions[0]?.created_at)}
+                        <div className="text-2xl font-bold">
+                            {summary ? formatDuration(summary.acd_seconds) : '—'}
                         </div>
                     </CardContent>
                 </Card>
             </div>
 
             <Card>
-                <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                        <History className="size-5 text-primary" />
-                        Recent Interactions
-                    </CardTitle>
-                    <CardDescription>
-                        Click View Journey to see the detailed linear timeline of any call.
-                    </CardDescription>
-                </CardHeader>
-                <CardContent>
-                    {isLoading ? (
-                        <div className="flex h-32 items-center justify-center">
-                            <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <CardContent className="pt-6">
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <div className="space-y-1.5">
+                            <Label htmlFor="search">Number or name</Label>
+                            <Input
+                                id="search"
+                                value={draft.search}
+                                placeholder="Caller, callee, or UUID"
+                                onChange={(e) => setDraft({ ...draft, search: e.target.value })}
+                                onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
+                            />
                         </div>
-                    ) : (
-                        <Table>
-                            <TableHeader>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="direction">Direction</Label>
+                            <Select
+                                value={draft.direction}
+                                onValueChange={(value) => setDraft({ ...draft, direction: value })}
+                            >
+                                <SelectTrigger id="direction">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="any">Any direction</SelectItem>
+                                    <SelectItem value="inbound">Inbound</SelectItem>
+                                    <SelectItem value="outbound">Outbound</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="date_from">From date</Label>
+                            <Input
+                                id="date_from"
+                                type="date"
+                                value={draft.date_from}
+                                onChange={(e) => setDraft({ ...draft, date_from: e.target.value })}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="date_to">To date</Label>
+                            <Input
+                                id="date_to"
+                                type="date"
+                                value={draft.date_to}
+                                onChange={(e) => setDraft({ ...draft, date_to: e.target.value })}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                        <Button onClick={applyFilters} size="sm">
+                            <Search className="size-4" />
+                            Apply filters
+                        </Button>
+                        {hasFilters && (
+                            <Button onClick={clearFilters} size="sm" variant="ghost">
+                                <X className="size-4" />
+                                Clear
+                            </Button>
+                        )}
+                        <Button
+                            onClick={() => void exportCsv()}
+                            size="sm"
+                            variant="outline"
+                            disabled={isExporting}
+                            className="ml-auto"
+                        >
+                            <Download className="size-4" />
+                            {isExporting ? 'Exporting…' : 'Export CSV'}
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="pt-6">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-10" />
+                                <TableHead>From</TableHead>
+                                <TableHead>To</TableHead>
+                                <TableHead>Started</TableHead>
+                                <TableHead>Ring</TableHead>
+                                <TableHead>Talk</TableHead>
+                                <TableHead>Result</TableHead>
+                                <TableHead>Recording</TableHead>
+                                <TableHead className="text-right">Journey</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {isLoading ? (
                                 <TableRow>
-                                    <TableHead className="w-10"></TableHead>
-                                    <TableHead>Call Identity</TableHead>
-                                    <TableHead>Status</TableHead>
-                                    <TableHead>Outcome</TableHead>
-                                    <TableHead>Time</TableHead>
-                                    <TableHead className="text-right">Action</TableHead>
+                                    <TableCell colSpan={9} className="py-10 text-center">
+                                        <div className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                                    </TableCell>
                                 </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {sessions.map((session) => (
-                                    <TableRow key={session.id}>
-                                        <TableCell>
-                                            {directionIcon(null)} {/* direction field coming from CDR reconciliation soon */}
-                                        </TableCell>
-                                        <TableCell>
-                                            <div className="space-y-0.5">
-                                                <div className="flex items-center gap-2 font-medium">
-                                                    <span>{session.call_uuid.substring(0, 13)}...</span>
+                            ) : isError ? (
+                                <TableRow>
+                                    <TableCell colSpan={9} className="py-10 text-center text-sm text-destructive">
+                                        Could not load call history.
+                                    </TableCell>
+                                </TableRow>
+                            ) : cdrs.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={9} className="py-10 text-center text-muted-foreground">
+                                        {hasFilters
+                                            ? 'No calls match these filters.'
+                                            : 'No calls recorded yet. Call records appear here once the CDR watcher has ingested them.'}
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                cdrs.map((cdr) => {
+                                    const result = describeResult(cdr);
+                                    const ring = ringSeconds(cdr);
+                                    const recording = cdr.recordings?.[0];
+
+                                    return (
+                                        <TableRow key={cdr.id}>
+                                            <TableCell title={cdr.direction ?? 'Unknown direction'}>
+                                                {directionIcon(cdr.direction)}
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className="font-mono text-sm">
+                                                    {cdr.caller_id_number || '—'}
                                                 </div>
-                                                <p className="font-mono text-[10px] text-muted-foreground">
-                                                    {session.id}
-                                                </p>
-                                            </div>
-                                        </TableCell>
-                                        <TableCell>
-                                            <Badge variant={statusVariant(session.state)}>
-                                                {formatStatus(session.state)}
-                                            </Badge>
-                                        </TableCell>
-                                        <TableCell>
-                                            <div className="flex items-center gap-2 text-sm">
-                                                {session.winner?.attempt_id ? (
-                                                    <CheckCircle2 className="size-3.5 text-emerald-600" />
+                                                {cdr.caller_id_name ? (
+                                                    <div className="text-xs text-muted-foreground">
+                                                        {cdr.caller_id_name}
+                                                    </div>
+                                                ) : null}
+                                            </TableCell>
+                                            <TableCell className="font-mono text-sm">
+                                                {cdr.destination_number || '—'}
+                                            </TableCell>
+                                            <TableCell className="text-xs text-muted-foreground">
+                                                {formatDateTime(cdr.start_stamp)}
+                                            </TableCell>
+                                            <TableCell className="text-sm">
+                                                {ring === null ? '—' : formatDuration(ring)}
+                                            </TableCell>
+                                            <TableCell className="text-sm">
+                                                {formatDuration(cdr.billsec)}
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge
+                                                    variant={result.variant}
+                                                    title={cdr.hangup_cause ?? undefined}
+                                                >
+                                                    {result.label}
+                                                </Badge>
+                                            </TableCell>
+                                            <TableCell>
+                                                {recording ? (
+                                                    <RecordingPlayer
+                                                        downloadUrl={`${organizationApiPrefix}/recordings/${recording.id}/download`}
+                                                        format={recording.format}
+                                                        compact
+                                                    />
+                                                ) : cdr.has_recording ? (
+                                                    <span
+                                                        className="text-xs text-muted-foreground"
+                                                        title="FreeSWITCH recorded this call but the file has not been ingested yet."
+                                                    >
+                                                        Pending
+                                                    </span>
                                                 ) : (
-                                                    <Clock3 className="size-3.5 text-muted-foreground" />
+                                                    <span className="text-xs text-muted-foreground">—</span>
                                                 )}
-                                                <span className="truncate max-w-[200px]">{sessionOutcome(session)}</span>
-                                            </div>
-                                        </TableCell>
-                                        <TableCell className="text-xs text-muted-foreground">
-                                            {formatDateTime(session.started_at)}
-                                        </TableCell>
-                                        <TableCell className="text-right">
-                                            <Button variant="ghost" size="sm" asChild className="h-8">
-                                                <Link to={`/admin/interactions/${session.id}`}>
-                                                    View Journey
-                                                    <ArrowRight className="ml-1 size-3.5" />
-                                                </Link>
-                                            </Button>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                                {sessions.length === 0 && (
-                                    <TableRow>
-                                        <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
-                                            No call history found.
-                                        </TableCell>
-                                    </TableRow>
-                                )}
-                            </TableBody>
-                        </Table>
-                    )}
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                                {cdr.call_session_id ? (
+                                                    <Button variant="ghost" size="sm" asChild className="h-8">
+                                                        <Link to={`/admin/interactions/${cdr.call_session_id}`}>
+                                                            View
+                                                            <ArrowRight className="ml-1 size-3.5" />
+                                                        </Link>
+                                                    </Button>
+                                                ) : (
+                                                    <span
+                                                        className="text-xs text-muted-foreground"
+                                                        title="This call was not traced through the delivery pipeline."
+                                                    >
+                                                        —
+                                                    </span>
+                                                )}
+                                            </TableCell>
+                                        </TableRow>
+                                    );
+                                })
+                            )}
+                        </TableBody>
+                    </Table>
+
+                    <Pagination meta={data?.meta} onPageChange={setPage} itemLabel="calls" />
                 </CardContent>
             </Card>
         </div>

--- a/frontend/src/pages/admin/DeviceProfilesPage.tsx
+++ b/frontend/src/pages/admin/DeviceProfilesPage.tsx
@@ -26,7 +26,7 @@ export default function DeviceProfilesPage() {
 
     // The device list stores only extension_id, so extensions are fetched to
     // render a human-readable number instead of a UUID.
-    const { data: extensions = [] } = useQuery<Extension[]>({
+    const { data: extensions = [], isPending: isResolvingExtensions } = useQuery<Extension[]>({
         queryKey: ['extensions', activeOrganization?.id],
         queryFn: async () => {
             if (!activeOrganization) return [];
@@ -108,8 +108,13 @@ export default function DeviceProfilesPage() {
                                             if (!deviceProfile.extension_id) return '-';
                                             const extension = extensionsById.get(deviceProfile.extension_id);
                                             if (!extension) {
+                                                // Distinguish "still fetching the
+                                                // extension list" from "the assigned
+                                                // extension no longer exists".
                                                 return (
-                                                    <span className="text-muted-foreground">Unknown extension</span>
+                                                    <span className="text-muted-foreground">
+                                                        {isResolvingExtensions ? '…' : 'Unknown extension'}
+                                                    </span>
                                                 );
                                             }
                                             return (

--- a/frontend/src/pages/admin/DeviceProfilesPage.tsx
+++ b/frontend/src/pages/admin/DeviceProfilesPage.tsx
@@ -18,11 +18,27 @@ import {
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
 import { useApiMutation } from '@/lib/api-hooks';
-import type { DeviceProfile } from '@/types/models';
+import type { DeviceProfile, Extension } from '@/types/models';
 
 export default function DeviceProfilesPage() {
     const { activeOrganization } = useOrganization();
     const [deviceProfileToDelete, setDeviceProfileToDelete] = useState<DeviceProfile | null>(null);
+
+    // The device list stores only extension_id, so extensions are fetched to
+    // render a human-readable number instead of a UUID.
+    const { data: extensions = [] } = useQuery<Extension[]>({
+        queryKey: ['extensions', activeOrganization?.id],
+        queryFn: async () => {
+            if (!activeOrganization) return [];
+            const response = await api.get(`organizations/${activeOrganization.id}/extensions`, {
+                params: { per_page: 500 },
+            });
+            return response.data.data;
+        },
+        enabled: !!activeOrganization,
+    });
+
+    const extensionsById = new Map(extensions.map((extension) => [extension.id, extension]));
 
     const { data: deviceProfiles = [], isLoading } = useQuery<DeviceProfile[]>({
         queryKey: ['device-profiles', activeOrganization?.id],
@@ -87,7 +103,30 @@ export default function DeviceProfilesPage() {
                                     <TableCell className="font-medium">{deviceProfile.name}</TableCell>
                                     <TableCell>{deviceProfile.vendor || '-'}</TableCell>
                                     <TableCell>{deviceProfile.mac_address || '-'}</TableCell>
-                                    <TableCell>{deviceProfile.extension_id || '-'}</TableCell>
+                                    <TableCell>
+                                        {(() => {
+                                            if (!deviceProfile.extension_id) return '-';
+                                            const extension = extensionsById.get(deviceProfile.extension_id);
+                                            if (!extension) {
+                                                return (
+                                                    <span className="text-muted-foreground">Unknown extension</span>
+                                                );
+                                            }
+                                            return (
+                                                <Link
+                                                    to={`/admin/extensions/${extension.id}`}
+                                                    className="font-medium text-primary hover:underline"
+                                                >
+                                                    {extension.extension}
+                                                    {extension.owner_label ? (
+                                                        <span className="ml-1.5 font-normal text-muted-foreground">
+                                                            {extension.owner_label}
+                                                        </span>
+                                                    ) : null}
+                                                </Link>
+                                            );
+                                        })()}
+                                    </TableCell>
                                     <TableCell>
                                         <Badge variant={deviceProfile.is_active ? 'default' : 'secondary'}>
                                             {deviceProfile.is_active ? 'Active' : 'Inactive'}

--- a/frontend/src/pages/admin/DidFormPage.tsx
+++ b/frontend/src/pages/admin/DidFormPage.tsx
@@ -37,7 +37,7 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { Did, Extension, Flow, Gateway } from '@/types/models';
+import type { Did, EffectiveRecordingPolicy, Extension, Flow, Gateway, RecordingPolicyResolution } from '@/types/models';
 
 const recordingPolicyOptions = [
     { value: 'inherit', label: 'Inherit' },
@@ -47,12 +47,32 @@ const recordingPolicyOptions = [
     { value: 'outgoing', label: 'Outgoing only' },
 ] as const;
 
+const recordingModeLabels: Record<string, string> = {
+    inherit: 'Inherit',
+    off: 'Not recording',
+    all: 'Recording all calls',
+    incoming: 'Recording incoming calls',
+    outgoing: 'Recording outgoing calls',
+};
+
+function describeResolution(resolution: RecordingPolicyResolution, organizationName: string): string {
+    const modeLabel = resolution.should_record
+        ? recordingModeLabels[resolution.resolved_mode] ?? resolution.resolved_mode
+        : 'Not recording';
+
+    if (resolution.winning_scope === 'organization') {
+        return `${modeLabel} — inherited from organization "${organizationName}"`;
+    }
+
+    return modeLabel;
+}
+
 const didSchema = z.object({
     number: z.string().min(1, 'Number is required'),
     description: z.string().optional(),
     recording_policy: z.enum(['inherit', 'off', 'all', 'incoming', 'outgoing']),
     destination_type: z.enum(['extension', 'flow'], {
-        errorMap: () => ({ message: 'Destination type is required' }),
+        error: 'Destination type is required',
     }),
     destination_id: z.string().uuid('Destination is required'),
     is_active: z.boolean(),
@@ -284,6 +304,15 @@ export default function DidFormPage() {
         queryKey: ['did', currentDidId],
         queryFn: async () => {
             const res = await api.get(`${organizationApiPrefix}/dids/${currentDidId}`);
+            return res.data.data;
+        },
+        enabled: isEdit && !!currentDidId && !!activeOrganization,
+    });
+
+    const { data: effectivePolicy } = useQuery<EffectiveRecordingPolicy>({
+        queryKey: ['did-recording-policy-effective', currentDidId],
+        queryFn: async () => {
+            const res = await api.get(`${organizationApiPrefix}/dids/${currentDidId}/recording-policy/effective`);
             return res.data.data;
         },
         enabled: isEdit && !!currentDidId && !!activeOrganization,
@@ -624,6 +653,18 @@ export default function DidFormPage() {
                                                         </SelectContent>
                                                     </Select>
                                                     <FormDescription>Override inbound automatic recording for calls answered from this number.</FormDescription>
+                                                    {isEdit && effectivePolicy ? (
+                                                        <div className="space-y-1 rounded-md border border-border/70 bg-muted/30 p-3 text-sm">
+                                                            <p>
+                                                                <span className="font-medium">Effective (inbound):</span>{' '}
+                                                                {describeResolution(effectivePolicy.inbound, activeOrganization.name)}
+                                                            </p>
+                                                            <p>
+                                                                <span className="font-medium">Effective (outbound):</span>{' '}
+                                                                {describeResolution(effectivePolicy.outbound, activeOrganization.name)}
+                                                            </p>
+                                                        </div>
+                                                    ) : null}
                                                     <FormMessage />
                                                 </FormItem>
                                             )}

--- a/frontend/src/pages/admin/DidFormPage.tsx
+++ b/frontend/src/pages/admin/DidFormPage.tsx
@@ -418,6 +418,10 @@ export default function DidFormPage() {
             setSavedDidId(savedDid.id);
             queryClient.invalidateQueries({ queryKey: ['dids'] });
             queryClient.setQueryData(['did', savedDid.id], savedDid);
+            // The resolved policy is derived server-side, so the "what actually
+            // happens" panel keeps showing the pre-save answer unless it is
+            // refetched — the most misleading moment to be stale.
+            queryClient.invalidateQueries({ queryKey: ['did-recording-policy-effective', savedDid.id] });
             numberForm.reset(toDidFormValues(savedDid));
             toast.success(currentDidId ? 'Number updated.' : 'Number created.');
 

--- a/frontend/src/pages/admin/DidsPage.tsx
+++ b/frontend/src/pages/admin/DidsPage.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { Plus, Hash, Pencil, Trash2, Activity } from 'lucide-react';
 
 import { useAuth } from '@/context/AuthContext';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import { useOrganization } from '@/context/OrganizationContext';
 import type { Did } from '@/types/models';
 import { Button } from '@/components/ui/button';
@@ -65,7 +66,6 @@ export default function DidsPage() {
     const { user } = useAuth();
     const { activeOrganization, organizationApiPrefix } = useOrganization();
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
     const [didToDelete, setDidToDelete] = useState<Did | null>(null);
     const isSuperadmin = user?.role === 'superadmin';
 
@@ -95,14 +95,12 @@ export default function DidsPage() {
         [gatewayStatuses],
     );
 
-    const deleteMutation = useMutation({
+    const deleteMutation = useApiMutation({
         mutationFn: async (id: string) => {
             return api.delete(`${organizationApiPrefix}/dids/${id}`);
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['dids'] });
-            setDidToDelete(null);
-        },
+        invalidateQueries: [['dids']],
+        onSuccess: () => setDidToDelete(null),
     });
 
     if (!activeOrganization) {

--- a/frontend/src/pages/admin/ExtensionDetailPage.tsx
+++ b/frontend/src/pages/admin/ExtensionDetailPage.tsx
@@ -166,7 +166,13 @@ export default function ExtensionDetailPage() {
                                     </div>
                                     <div>
                                         <p className="text-muted-foreground">Password</p>
-                                        <p className="mt-1 break-all font-mono">{sipConfig.sip_password || 'Hidden'}</p>
+                                        {sipConfig.sip_password ? (
+                                            <p className="mt-1 break-all font-mono">{sipConfig.sip_password}</p>
+                                        ) : (
+                                            <p className="mt-1 text-sm italic text-muted-foreground">
+                                                Not available — reset the extension password to issue new credentials.
+                                            </p>
+                                        )}
                                     </div>
                                     <div className="flex items-center gap-2 mt-4 pt-4 border-t">
                                         <p className="text-muted-foreground">WebRTC support:</p>
@@ -186,8 +192,13 @@ export default function ExtensionDetailPage() {
                                                     `Domain / Realm: ${sipConfig.sip_domain || ''}`,
                                                     `Transport: ${sipConfig.sip_transport || 'UDP/TCP'}`,
                                                     `Username: ${sipConfig.sip_username || extension.extension}`,
-                                                    `Password: ${sipConfig.sip_password || 'Hidden'}`,
                                                 ];
+                                                // Never put a placeholder like "Hidden" in the clipboard — that reads as
+                                                // a real value and would hand out a non-working credential. Omit the
+                                                // line and warn instead so the toast can't claim a fake success.
+                                                if (sipConfig.sip_password) {
+                                                    lines.push(`Password: ${sipConfig.sip_password}`);
+                                                }
                                                 if (sipConfig.sip_tls_server) {
                                                     lines.push(`TLS Server: ${sipConfig.sip_tls_server}`);
                                                 }
@@ -195,7 +206,11 @@ export default function ExtensionDetailPage() {
                                                     lines.push(`WebSocket URL: ${sipConfig.websocket_url}`);
                                                 }
                                                 navigator.clipboard.writeText(lines.join('\n'));
-                                                toast.success('SIP credentials copied to clipboard');
+                                                if (sipConfig.sip_password) {
+                                                    toast.success('SIP credentials copied to clipboard');
+                                                } else {
+                                                    toast.warning('Copied SIP details, but no password is available — reset it to get working credentials.');
+                                                }
                                             }}
                                         >
                                             <Copy className="mr-2 size-4" />

--- a/frontend/src/pages/admin/ExtensionDetailPage.tsx
+++ b/frontend/src/pages/admin/ExtensionDetailPage.tsx
@@ -186,7 +186,7 @@ export default function ExtensionDetailPage() {
                                     <div className="flex justify-end pt-2">
                                         <Button
                                             variant="outline"
-                                            onClick={() => {
+                                            onClick={async () => {
                                                 const lines = [
                                                     `SIP Server: ${sipConfig.sip_server || ''}`,
                                                     `Domain / Realm: ${sipConfig.sip_domain || ''}`,
@@ -205,7 +205,17 @@ export default function ExtensionDetailPage() {
                                                 if (sipConfig.enabled && sipConfig.websocket_url) {
                                                     lines.push(`WebSocket URL: ${sipConfig.websocket_url}`);
                                                 }
-                                                navigator.clipboard.writeText(lines.join('\n'));
+                                                // The write is awaited: it rejects when the
+                                                // clipboard is blocked (no permission, insecure
+                                                // context), and reporting success regardless would
+                                                // send someone to paste nothing.
+                                                try {
+                                                    await navigator.clipboard.writeText(lines.join('\n'));
+                                                } catch {
+                                                    toast.error('Could not copy to the clipboard. Select the values above and copy them manually.');
+                                                    return;
+                                                }
+
                                                 if (sipConfig.sip_password) {
                                                     toast.success('SIP credentials copied to clipboard');
                                                 } else {

--- a/frontend/src/pages/admin/ExtensionFormPage.tsx
+++ b/frontend/src/pages/admin/ExtensionFormPage.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/components/ui/select';
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
-import type { DeviceProfile, Did, Gateway, User } from '@/types/models';
+import type { DeviceProfile, Did, EffectiveRecordingPolicy, Gateway, RecordingPolicyResolution, User } from '@/types/models';
 
 const ownerTypes = ['unassigned', 'user', 'device'] as const;
 const recordingPolicyOptions = [
@@ -44,6 +44,34 @@ const recordingPolicyOptions = [
     { value: 'incoming', label: 'Incoming only' },
     { value: 'outgoing', label: 'Outgoing only' },
 ] as const;
+
+const recordingModeLabels: Record<string, string> = {
+    inherit: 'Inherit',
+    off: 'Not recording',
+    all: 'Recording all calls',
+    incoming: 'Recording incoming calls',
+    outgoing: 'Recording outgoing calls',
+};
+
+function describeResolution(
+    resolution: RecordingPolicyResolution,
+    organizationName: string,
+    didLabel: string | null,
+): string {
+    const modeLabel = resolution.should_record
+        ? recordingModeLabels[resolution.resolved_mode] ?? resolution.resolved_mode
+        : 'Not recording';
+
+    if (resolution.winning_scope === 'organization') {
+        return `${modeLabel} — inherited from organization "${organizationName}"`;
+    }
+
+    if (resolution.winning_scope === 'did') {
+        return `${modeLabel} — inherited from DID${didLabel ? ` ${didLabel}` : ''}`;
+    }
+
+    return modeLabel;
+}
 
 const extensionSchema = z.object({
     extension: z.string().min(1, 'Extension number is required'),
@@ -215,6 +243,8 @@ export default function ExtensionFormPage() {
     const { activeOrganization, organizationApiPrefix } = useOrganization();
 
     const form = useForm<ExtensionFormValues>({
+        // Cast needed: pre-existing zod v4/@hookform-resolvers generics gap —
+        // see the identical cast in OrganizationFormPage for the full note.
         resolver: zodResolver(extensionSchema),
         defaultValues: {
             extension: '',
@@ -243,6 +273,15 @@ export default function ExtensionFormPage() {
         queryKey: ['extension', activeOrganization?.id, id],
         queryFn: async () => {
             const response = await api.get(`${organizationApiPrefix}/extensions/${id}`);
+            return response.data.data;
+        },
+        enabled: isEdit && Boolean(activeOrganization),
+    });
+
+    const { data: effectivePolicy } = useQuery<EffectiveRecordingPolicy>({
+        queryKey: ['extension-recording-policy-effective', activeOrganization?.id, id],
+        queryFn: async () => {
+            const response = await api.get(`${organizationApiPrefix}/extensions/${id}/recording-policy/effective`);
             return response.data.data;
         },
         enabled: isEdit && Boolean(activeOrganization),
@@ -410,6 +449,21 @@ export default function ExtensionFormPage() {
 
     const allowedOutboundDids = dids.filter((did) => did.is_active ?? true);
     const allowedOutboundGateways = gateways.filter((gateway) => gateway.is_active ?? gateway.enabled ?? true);
+
+    const effectiveDidLabel = (() => {
+        const defaultOutboundDidId = extension?.default_outbound_did_id;
+        if (!defaultOutboundDidId) {
+            return null;
+        }
+
+        const matchedDid = dids.find((did) => did.id === defaultOutboundDidId);
+
+        if (!matchedDid) {
+            return null;
+        }
+
+        return matchedDid.description ? `${matchedDid.number} — ${matchedDid.description}` : matchedDid.number;
+    })();
 
     const availableUsers = users;
 
@@ -663,6 +717,18 @@ export default function ExtensionFormPage() {
                                                     </SelectContent>
                                                 </Select>
                                                 <FormDescription>Override automatic recording for calls answered by this extension.</FormDescription>
+                                                {isEdit && effectivePolicy ? (
+                                                    <div className="space-y-1 rounded-md border border-border/70 bg-muted/30 p-3 text-sm">
+                                                        <p>
+                                                            <span className="font-medium">Effective (inbound):</span>{' '}
+                                                            {describeResolution(effectivePolicy.inbound, activeOrganization.name, effectiveDidLabel)}
+                                                        </p>
+                                                        <p>
+                                                            <span className="font-medium">Effective (outbound):</span>{' '}
+                                                            {describeResolution(effectivePolicy.outbound, activeOrganization.name, effectiveDidLabel)}
+                                                        </p>
+                                                    </div>
+                                                ) : null}
                                                 <FormMessage />
                                             </FormItem>
                                         )}

--- a/frontend/src/pages/admin/ExtensionsPage.tsx
+++ b/frontend/src/pages/admin/ExtensionsPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Eye, Phone as PhoneIcon, Plus, SquarePen, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -32,12 +32,12 @@ import {
 } from '@/components/ui/table';
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import type { Extension } from '@/types/models';
 
 export default function ExtensionsPage() {
     const { activeOrganization, organizationApiPrefix } = useOrganization();
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
     const [extensionToDelete, setExtensionToDelete] = useState<Extension | null>(null);
 
     const { data: extensions = [], isLoading } = useQuery({
@@ -61,17 +61,15 @@ export default function ExtensionsPage() {
         refetchInterval: 15_000,
     });
 
-    const deleteMutation = useMutation({
+    const deleteMutation = useApiMutation({
         mutationFn: async (id: string) => {
             await api.delete(`${organizationApiPrefix}/extensions/${id}`);
         },
-        onSuccess: async () => {
-            await Promise.all([
-                queryClient.invalidateQueries({ queryKey: ['extensions', activeOrganization?.id] }),
-                queryClient.invalidateQueries({ queryKey: ['extension-status', activeOrganization?.id] }),
-            ]);
-            setExtensionToDelete(null);
-        },
+        invalidateQueries: [
+            ['extensions', activeOrganization?.id || ''],
+            ['extension-status', activeOrganization?.id || ''],
+        ],
+        onSuccess: () => setExtensionToDelete(null),
     });
 
     if (!activeOrganization) {
@@ -83,6 +81,8 @@ export default function ExtensionsPage() {
     }
 
     const registeredCount = Object.values(statusMap).filter((s) => s.status === 'registered').length;
+    // 0 means unlimited licensing in this codebase, so only render "of N licensed" when capped.
+    const maxExtensions = activeOrganization.max_extensions ?? 0;
 
     return (
         <div className="space-y-6 p-6 lg:p-8">
@@ -104,11 +104,13 @@ export default function ExtensionsPage() {
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between pb-2">
                         <CardTitle className="text-sm font-medium text-muted-foreground">
-                            Total Capacity
+                            Extensions Provisioned
                         </CardTitle>
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">{extensions.length}</div>
+                        <div className="text-2xl font-bold">
+                            {maxExtensions > 0 ? `${extensions.length} of ${maxExtensions} licensed` : extensions.length}
+                        </div>
                     </CardContent>
                 </Card>
                 <Card>

--- a/frontend/src/pages/admin/OrganizationFormPage.tsx
+++ b/frontend/src/pages/admin/OrganizationFormPage.tsx
@@ -35,22 +35,49 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import api from '@/lib/api';
-import type { Organization } from '@/types/models';
+import type { EffectiveRecordingPolicy, Organization, RecordingPolicyResolution } from '@/types/models';
 
 const organizationStatuses = ['trial', 'active', 'suspended', 'terminated'] as const;
+// "Inherit" is deliberately excluded here: at organization scope there is no
+// parent policy to inherit from, so it silently resolves to "off". DID and
+// extension scopes keep offering it since they inherit from this level.
 const recordingPolicyOptions = [
-    { value: 'inherit', label: 'Inherit' },
     { value: 'off', label: 'Off' },
     { value: 'all', label: 'All calls' },
     { value: 'incoming', label: 'Incoming only' },
     { value: 'outgoing', label: 'Outgoing only' },
 ] as const;
 
+const recordingModeLabels: Record<string, string> = {
+    inherit: 'Inherit',
+    off: 'Not recording',
+    all: 'Recording all calls',
+    incoming: 'Recording incoming calls',
+    outgoing: 'Recording outgoing calls',
+};
+
+function describeResolution(resolution: RecordingPolicyResolution): string {
+    const modeLabel = resolution.should_record
+        ? recordingModeLabels[resolution.resolved_mode] ?? resolution.resolved_mode
+        : 'Not recording';
+
+    if (resolution.winning_scope === null || resolution.winning_scope === 'organization') {
+        return modeLabel;
+    }
+
+    return `${modeLabel} — ${resolution.reason}`;
+}
+
 const organizationSchema = z.object({
     name: z.string().min(1, 'Name is required'),
     domain_prefix: z.string().min(1, 'Domain prefix is required'),
     status: z.string().min(1, 'Status is required'),
+    // Kept broader than the form's own options so a legacy "inherit" value
+    // (accepted by the backend for compatibility) still passes validation.
     recording_policy: z.enum(['inherit', 'off', 'all', 'incoming', 'outgoing']),
+    // Matches how max_extensions and the other quota fields below use 0 for
+    // "unlimited": 0 here means "keep recordings forever".
+    recording_retention_days: z.coerce.number().min(0),
     max_extensions: z.coerce.number().min(0),
     max_concurrent_calls: z.coerce.number().min(0),
     max_dids: z.coerce.number().min(0),
@@ -82,6 +109,7 @@ const serializeOrganizationPayload = (values: OrganizationFormValues) => ({
     domain_prefix: normalizeDomainPrefix(values.domain_prefix),
     status: values.status,
     recording_policy: values.recording_policy,
+    recording_retention_days: values.recording_retention_days,
     max_extensions: values.max_extensions,
     max_concurrent_calls: values.max_concurrent_calls,
     max_dids: values.max_dids,
@@ -134,12 +162,19 @@ export default function OrganizationFormPage() {
     const initializedCreateForm = useRef(false);
 
     const form = useForm<OrganizationFormValues>({
+        // Cast needed: @hookform/resolvers types the resolver's field-values
+        // generic from zod's *input* type, which is `unknown` for z.coerce
+        // fields — mismatched against the `number` *output* type react-hook-form
+        // is instantiated with here. Pre-existing zod v4/resolver generics gap;
+        // several other admin forms with coerced numeric fields hit the same
+        // TS error (QueueFormPage, TeamFormPage, UserFormPage, etc.).
         resolver: zodResolver(organizationSchema),
         defaultValues: {
             name: '',
             domain_prefix: '',
             status: 'active',
             recording_policy: 'off',
+            recording_retention_days: 0,
             max_extensions: 0,
             max_concurrent_calls: 0,
             max_dids: 0,
@@ -174,6 +209,7 @@ export default function OrganizationFormPage() {
                 domain_prefix: '',
                 status: 'active',
                 recording_policy: 'off',
+                recording_retention_days: 0,
                 max_extensions: 0,
                 max_concurrent_calls: 0,
                 max_dids: 0,
@@ -190,6 +226,7 @@ export default function OrganizationFormPage() {
                 domain_prefix: organization.domain_prefix ?? organization.domain ?? '',
                 status: normalizeOrganizationStatus(organization.status),
                 recording_policy: organization.recording_policy ?? 'off',
+                recording_retention_days: organization.recording_retention_days ?? 0,
                 max_extensions: organization.max_extensions ?? 0,
                 max_concurrent_calls: organization.max_concurrent_calls ?? 0,
                 max_dids: organization.max_dids ?? 0,
@@ -223,11 +260,20 @@ export default function OrganizationFormPage() {
                     return;
                 }
 
-                if (field === 'domain_prefix' || field === 'name' || field === 'status' || field === 'recording_policy' || field === 'max_extensions' || field === 'max_concurrent_calls' || field === 'max_dids' || field === 'max_teams' || field === 'is_active') {
+                if (field === 'domain_prefix' || field === 'name' || field === 'status' || field === 'recording_policy' || field === 'recording_retention_days' || field === 'max_extensions' || field === 'max_concurrent_calls' || field === 'max_dids' || field === 'max_teams' || field === 'is_active') {
                     form.setError(field, { type: 'server', message: messages[0] });
                 }
             });
         },
+    });
+
+    const { data: effectivePolicy } = useQuery<EffectiveRecordingPolicy>({
+        queryKey: ['organization-recording-policy-effective', id],
+        queryFn: async () => {
+            const response = await api.get(`organizations/${id}/recording-policy/effective`);
+            return response.data.data;
+        },
+        enabled: isEdit,
     });
 
     const composedDomain = useMemo(() => {
@@ -445,6 +491,18 @@ export default function OrganizationFormPage() {
                                                     </SelectContent>
                                                 </Select>
                                                 <FormDescription>Organization default for automatic call recording.</FormDescription>
+                                                {isEdit && effectivePolicy ? (
+                                                    <div className="space-y-1 rounded-md border border-border/70 bg-muted/30 p-3 text-sm">
+                                                        <p>
+                                                            <span className="font-medium">Effective (inbound):</span>{' '}
+                                                            {describeResolution(effectivePolicy.inbound)}
+                                                        </p>
+                                                        <p>
+                                                            <span className="font-medium">Effective (outbound):</span>{' '}
+                                                            {describeResolution(effectivePolicy.outbound)}
+                                                        </p>
+                                                    </div>
+                                                ) : null}
                                                 <FormMessage />
                                             </FormItem>
                                         )}
@@ -452,6 +510,24 @@ export default function OrganizationFormPage() {
                                 </div>
 
                                 <div className="grid gap-6 md:grid-cols-2">
+                                    <FormField
+                                        control={form.control}
+                                        name="recording_retention_days"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabel>Recording retention (days)</FormLabel>
+                                                <FormControl>
+                                                    <Input type="number" min="0" placeholder="0 = keep forever" {...field} />
+                                                </FormControl>
+                                                <FormDescription>
+                                                    Recordings older than this many days are permanently deleted by the nightly
+                                                    retention job. Leave empty or set to 0 to keep recordings forever.
+                                                </FormDescription>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+
                                     <FormField
                                         control={form.control}
                                         name="max_extensions"

--- a/frontend/src/pages/admin/OrganizationSettingsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/form';
 import { Textarea } from '@/components/ui/textarea';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 
 const organizationSettingsSchema = z.object({
     settingsText: z.string().superRefine((value: string, ctx: z.RefinementCtx) => {
@@ -49,7 +50,6 @@ type OrganizationSettingsValues = z.infer<typeof organizationSettingsSchema>;
 export default function OrganizationSettingsPage() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
 
     const form = useForm<OrganizationSettingsValues>({
         resolver: zodResolver(organizationSettingsSchema),
@@ -84,19 +84,18 @@ export default function OrganizationSettingsPage() {
         }
     }, [settings, form]);
 
-    const mutation = useMutation({
+    const mutation = useApiMutation({
         mutationFn: async (values: OrganizationSettingsValues) => {
             return api.put(`organizations/${id}/settings`, {
                 settings: JSON.parse(values.settingsText),
             });
         },
-        onSuccess: async () => {
-            await Promise.all([
-                queryClient.invalidateQueries({ queryKey: ['organization-settings', id] }),
-                queryClient.invalidateQueries({ queryKey: ['organization', id] }),
-                queryClient.invalidateQueries({ queryKey: ['organizations'] }),
-            ]);
-        },
+        successMessage: 'Organization settings saved successfully',
+        invalidateQueries: [
+            ['organization-settings', id || ''],
+            ['organization', id || ''],
+            ['organizations'],
+        ],
     });
 
     return (

--- a/frontend/src/pages/admin/OrganizationsPage.tsx
+++ b/frontend/src/pages/admin/OrganizationsPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Building2, CalendarDays, Globe, Plus, Settings, SquarePen, Trash2, Users } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -32,12 +32,12 @@ import {
 } from '@/components/ui/table';
 import { useOrganization } from '@/context/OrganizationContext';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import type { Organization } from '@/types/models';
 
 export default function OrganizationsPage() {
     const { switchOrganization, activeOrganization } = useOrganization();
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
     const [organizationToDelete, setOrganizationToDelete] = useState<Organization | null>(null);
 
     const { data: organizations = [], isLoading } = useQuery({
@@ -50,12 +50,12 @@ export default function OrganizationsPage() {
 
     const activeOrganizations = organizations.filter((organization) => organization.is_active).length;
 
-    const deleteMutation = useMutation({
+    const deleteMutation = useApiMutation({
         mutationFn: async (id: string) => {
             await api.delete(`organizations/${id}`);
         },
-        onSuccess: async (_, deletedId) => {
-            await queryClient.invalidateQueries({ queryKey: ['organizations'] });
+        invalidateQueries: [['organizations']],
+        onSuccess: (_, deletedId) => {
             if (activeOrganization && String(activeOrganization.id) === deletedId) {
                 const nextOrganization = organizations.find((organization) => String(organization.id) !== deletedId);
                 if (nextOrganization) {

--- a/frontend/src/pages/admin/RecordingsPage.tsx
+++ b/frontend/src/pages/admin/RecordingsPage.tsx
@@ -1,0 +1,311 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Download, FileAudio, Search, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { RecordingPlayer } from '@/components/admin/RecordingPlayer';
+import { DeleteDialog } from '@/components/scaffolds/DeleteDialog';
+import { PageHeader } from '@/components/scaffolds/PageHeader';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Pagination } from '@/components/ui/pagination';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { useOrganization } from '@/context/OrganizationContext';
+import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
+import { downloadAuthenticatedFile, formatDuration, formatFileSize } from '@/lib/media';
+import type { PaginationMeta, Recording } from '@/types/models';
+
+interface Filters {
+    caller_id_number: string;
+    destination_number: string;
+    date_from: string;
+    date_to: string;
+}
+
+const EMPTY_FILTERS: Filters = {
+    caller_id_number: '',
+    destination_number: '',
+    date_from: '',
+    date_to: '',
+};
+
+function formatDateTime(value?: string | null): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+export default function RecordingsPage() {
+    const { activeOrganization, organizationApiPrefix } = useOrganization();
+    const queryClient = useQueryClient();
+
+    // Draft state is separate from applied state so typing in the filter bar
+    // does not refetch on every keystroke.
+    const [draft, setDraft] = useState<Filters>(EMPTY_FILTERS);
+    const [applied, setApplied] = useState<Filters>(EMPTY_FILTERS);
+    const [page, setPage] = useState(1);
+    const [toDelete, setToDelete] = useState<Recording | null>(null);
+
+    const queryKey = ['recordings', activeOrganization?.id, applied, page] as const;
+
+    const { data, isLoading, isError, error } = useQuery({
+        queryKey,
+        queryFn: async () => {
+            const response = await api.get<{ data: Recording[]; meta?: PaginationMeta }>(
+                `${organizationApiPrefix}/recordings`,
+                { params: { ...applied, page } },
+            );
+            return response.data;
+        },
+        enabled: Boolean(activeOrganization),
+    });
+
+    const deleteMutation = useApiMutation({
+        mutationFn: async (id: string) => {
+            await api.delete(`${organizationApiPrefix}/recordings/${id}`);
+        },
+        successMessage: 'Recording deleted',
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: ['recordings', activeOrganization?.id] });
+        },
+        onSettled: () => setToDelete(null),
+    });
+
+    const download = async (recording: Recording) => {
+        try {
+            await downloadAuthenticatedFile(
+                `${organizationApiPrefix}/recordings/${recording.id}/download`,
+                recording.file_name || `recording-${recording.id}.${recording.format ?? 'wav'}`,
+            );
+        } catch {
+            toast.error('Could not download this recording.');
+        }
+    };
+
+    const applyFilters = () => {
+        setApplied(draft);
+        setPage(1);
+    };
+
+    const clearFilters = () => {
+        setDraft(EMPTY_FILTERS);
+        setApplied(EMPTY_FILTERS);
+        setPage(1);
+    };
+
+    const hasFilters = Object.values(applied).some(Boolean);
+    const recordings = data?.data ?? [];
+
+    if (!activeOrganization) {
+        return (
+            <div className="flex h-64 items-center justify-center text-muted-foreground">
+                Select an organization to view recordings.
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6 p-6 lg:p-8">
+            <PageHeader
+                title="Call Recordings"
+                description="Play, download, and manage recorded calls for this organization."
+                breadcrumbs={`${activeOrganization.name} › Calls`}
+            />
+
+            <Card>
+                <CardContent className="pt-6">
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <div className="space-y-1.5">
+                            <Label htmlFor="caller">From number</Label>
+                            <Input
+                                id="caller"
+                                value={draft.caller_id_number}
+                                placeholder="e.g. +15550100"
+                                onChange={(e) => setDraft({ ...draft, caller_id_number: e.target.value })}
+                                onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="destination">To number</Label>
+                            <Input
+                                id="destination"
+                                value={draft.destination_number}
+                                placeholder="e.g. 1001"
+                                onChange={(e) => setDraft({ ...draft, destination_number: e.target.value })}
+                                onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="from">Recorded after</Label>
+                            <Input
+                                id="from"
+                                type="date"
+                                value={draft.date_from}
+                                onChange={(e) => setDraft({ ...draft, date_from: e.target.value })}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="to">Recorded before</Label>
+                            <Input
+                                id="to"
+                                type="date"
+                                value={draft.date_to}
+                                onChange={(e) => setDraft({ ...draft, date_to: e.target.value })}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="mt-4 flex items-center gap-2">
+                        <Button onClick={applyFilters} size="sm">
+                            <Search className="size-4" />
+                            Apply filters
+                        </Button>
+                        {hasFilters && (
+                            <Button onClick={clearFilters} size="sm" variant="ghost">
+                                <X className="size-4" />
+                                Clear
+                            </Button>
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="pt-6">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>From</TableHead>
+                                <TableHead>To</TableHead>
+                                <TableHead>Direction</TableHead>
+                                <TableHead>Recorded</TableHead>
+                                <TableHead>Length</TableHead>
+                                <TableHead>Size</TableHead>
+                                <TableHead>Playback</TableHead>
+                                <TableHead className="w-[100px] text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {isLoading ? (
+                                <TableRow>
+                                    <TableCell colSpan={8} className="py-10 text-center">
+                                        <div className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                                    </TableCell>
+                                </TableRow>
+                            ) : isError ? (
+                                <TableRow>
+                                    <TableCell colSpan={8} className="py-10 text-center text-sm text-destructive">
+                                        Could not load recordings.
+                                        {error instanceof Error ? ` ${error.message}` : ''}
+                                    </TableCell>
+                                </TableRow>
+                            ) : recordings.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={8} className="py-10 text-center text-muted-foreground">
+                                        {hasFilters ? (
+                                            <>No recordings match these filters. Try widening the date range.</>
+                                        ) : (
+                                            <>
+                                                No recordings yet. Calls are recorded when a recording policy is
+                                                active on the organization, the number, or the extension.
+                                            </>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                recordings.map((recording) => (
+                                    <TableRow key={recording.id}>
+                                        <TableCell className="font-mono text-sm">
+                                            {recording.caller_id_number || '—'}
+                                        </TableCell>
+                                        <TableCell className="font-mono text-sm">
+                                            {recording.destination_number || '—'}
+                                        </TableCell>
+                                        <TableCell>
+                                            {recording.direction ? (
+                                                <Badge variant="outline" className="capitalize">
+                                                    {recording.direction}
+                                                </Badge>
+                                            ) : (
+                                                '—'
+                                            )}
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatDateTime(recording.created_at)}
+                                        </TableCell>
+                                        <TableCell className="text-sm">{formatDuration(recording.duration)}</TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatFileSize(recording.file_size)}
+                                        </TableCell>
+                                        <TableCell>
+                                            <RecordingPlayer
+                                                downloadUrl={`${organizationApiPrefix}/recordings/${recording.id}/download`}
+                                                format={recording.format}
+                                                compact
+                                            />
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    onClick={() => void download(recording)}
+                                                    aria-label="Download recording"
+                                                >
+                                                    <Download className="size-4" />
+                                                </Button>
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    onClick={() => setToDelete(recording)}
+                                                    aria-label="Delete recording"
+                                                >
+                                                    <Trash2 className="size-4 text-destructive" />
+                                                </Button>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+
+                    <Pagination meta={data?.meta} onPageChange={setPage} itemLabel="recordings" />
+                </CardContent>
+            </Card>
+
+            <DeleteDialog
+                open={Boolean(toDelete)}
+                onOpenChange={(open) => !open && setToDelete(null)}
+                title="Delete recording"
+                description={
+                    <>
+                        Permanently delete the recording of the call from{' '}
+                        <strong>{toDelete?.caller_id_number || 'unknown'}</strong> to{' '}
+                        <strong>{toDelete?.destination_number || 'unknown'}</strong>? The audio file is removed
+                        from storage and cannot be recovered.
+                    </>
+                }
+                isDeleting={deleteMutation.isPending}
+                onConfirm={() => toDelete && deleteMutation.mutate(toDelete.id)}
+            />
+
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <FileAudio className="size-3.5" />
+                Recordings are retained according to this organization&rsquo;s retention policy. Access is
+                governed by the recordings permissions on each user.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/pages/admin/RecordingsPage.tsx
+++ b/frontend/src/pages/admin/RecordingsPage.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Pagination } from '@/components/ui/pagination';
+import { TablePagination } from '@/components/ui/table-pagination';
 import {
     Table,
     TableBody,
@@ -281,7 +281,7 @@ export default function RecordingsPage() {
                         </TableBody>
                     </Table>
 
-                    <Pagination meta={data?.meta} onPageChange={setPage} itemLabel="recordings" />
+                    <TablePagination meta={data?.meta} onPageChange={setPage} itemLabel="recordings" />
                 </CardContent>
             </Card>
 

--- a/frontend/src/pages/admin/RecordingsPage.tsx
+++ b/frontend/src/pages/admin/RecordingsPage.tsx
@@ -200,7 +200,13 @@ export default function RecordingsPage() {
                             {isLoading ? (
                                 <TableRow>
                                     <TableCell colSpan={8} className="py-10 text-center">
-                                        <div className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                                        <div role="status">
+                                            <div
+                                                className="mx-auto size-6 animate-spin rounded-full border-2 border-primary border-t-transparent"
+                                                aria-hidden="true"
+                                            />
+                                            <span className="sr-only">Loading recordings…</span>
+                                        </div>
                                     </TableCell>
                                 </TableRow>
                             ) : isError ? (

--- a/frontend/src/pages/admin/SipStatusPage.tsx
+++ b/frontend/src/pages/admin/SipStatusPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
     AlertCircle,
     CheckCircle,
@@ -42,6 +42,7 @@ import {
 } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 
 // ─── Types ───────────────────────────────────────────────────
 
@@ -91,7 +92,6 @@ interface HealthResponse {
 // ─── SIP Status Page ─────────────────────────────────────────
 
 export default function SipStatusPage() {
-    const queryClient = useQueryClient();
     const [confirmAction, setConfirmAction] = useState<{
         type: string;
         data: any;
@@ -157,49 +157,39 @@ export default function SipStatusPage() {
     });
 
     // Mutations
-    const reloadProfileMutation = useMutation({
+    const reloadProfileMutation = useApiMutation({
         mutationFn: async (profile: string) => {
             await api.post('admin/sip-status/profiles/reload', { profile });
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['admin-sip-profiles'] });
-        },
+        invalidateQueries: [['admin-sip-profiles']],
     });
 
-    const startProfileMutation = useMutation({
+    const startProfileMutation = useApiMutation({
         mutationFn: async (profile: string) => {
             await api.post('admin/sip-status/profiles/start', { profile });
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['admin-sip-profiles'] });
-        },
+        invalidateQueries: [['admin-sip-profiles']],
     });
 
-    const stopProfileMutation = useMutation({
+    const stopProfileMutation = useApiMutation({
         mutationFn: async (profile: string) => {
             await api.post('admin/sip-status/profiles/stop', { profile });
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['admin-sip-profiles'] });
-        },
+        invalidateQueries: [['admin-sip-profiles']],
     });
 
-    const killRegistrationMutation = useMutation({
+    const killRegistrationMutation = useApiMutation({
         mutationFn: async ({ user, realm }: { user: string; realm: string }) => {
             await api.post('admin/sip-status/registrations/kill', { user, realm });
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['admin-sip-registrations'] });
-        },
+        invalidateQueries: [['admin-sip-registrations']],
     });
 
-    const killGatewayMutation = useMutation({
+    const killGatewayMutation = useApiMutation({
         mutationFn: async (gateway: string) => {
             await api.post('admin/sip-status/gateways/kill', { gateway });
         },
-        onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['admin-sip-gateways'] });
-        },
+        invalidateQueries: [['admin-sip-gateways']],
     });
 
     const handleAction = (type: string, data: any) => {

--- a/frontend/src/pages/admin/SystemSettingsPage.tsx
+++ b/frontend/src/pages/admin/SystemSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
@@ -25,6 +25,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 
 const systemSettingsSchema = z.object({
     organization_domain_suffix: z.string().min(1, 'Domain suffix is required'),
@@ -39,7 +40,6 @@ type SystemSettingsValues = z.infer<typeof systemSettingsSchema>;
 
 export default function SystemSettingsPage() {
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
 
     const form = useForm<SystemSettingsValues>({
         resolver: zodResolver(systemSettingsSchema),
@@ -68,17 +68,15 @@ export default function SystemSettingsPage() {
         }
     }, [settings, form]);
 
-    const mutation = useMutation({
+    const mutation = useApiMutation({
         mutationFn: async (values: SystemSettingsValues) => {
             return api.put('admin/platform-settings', values);
         },
-        onSuccess: async () => {
-            await Promise.all([
-                queryClient.invalidateQueries({ queryKey: ['platform-settings'] }),
-                queryClient.invalidateQueries({ queryKey: ['organization', 'create'] }),
-                queryClient.invalidateQueries({ queryKey: ['organizations'] }),
-            ]);
-        },
+        invalidateQueries: [
+            ['platform-settings'],
+            ['organization', 'create'],
+            ['organizations'],
+        ],
     });
 
     return (

--- a/frontend/src/pages/admin/UserFormPage.tsx
+++ b/frontend/src/pages/admin/UserFormPage.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
@@ -33,6 +33,7 @@ import {
 } from '@/components/ui/select';
 import { useAuth } from '@/context/AuthContext';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import type { Organization } from '@/types/models';
 
 const userSchema = z.object({
@@ -49,7 +50,6 @@ export default function UserFormPage() {
     const { id } = useParams<{ id: string }>();
     const isEdit = Boolean(id && id !== 'new');
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
     const { user: authUser } = useAuth();
 
     const form = useForm<UserFormValues>({
@@ -119,7 +119,7 @@ export default function UserFormPage() {
         }
     }, [form, isSuperadmin, scopedOrganizationId, user]);
 
-    const mutation = useMutation({
+    const mutation = useApiMutation({
         mutationFn: async (values: UserFormValues) => {
             const payload = {
                 ...values,
@@ -136,10 +136,8 @@ export default function UserFormPage() {
 
             return api.post('users', payload);
         },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['users'] });
-            navigate('/admin/users');
-        },
+        invalidateQueries: [['users']],
+        onSuccess: () => navigate('/admin/users'),
     });
 
     return (

--- a/frontend/src/pages/admin/UserPermissionsPage.tsx
+++ b/frontend/src/pages/admin/UserPermissionsPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Save } from 'lucide-react';
 import { useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -14,12 +14,12 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import type { Permission } from '@/types/models';
 
 export default function UserPermissionsPage() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
 
     const { data: user } = useQuery({
         queryKey: ['user', id],
@@ -56,7 +56,7 @@ export default function UserPermissionsPage() {
         }, {});
     }, [availablePermissions]);
 
-    const mutation = useMutation({
+    const mutation = useApiMutation({
         mutationFn: async (nextPermissions: string[]) => {
             const toGrant = nextPermissions.filter((permission) => !assignedPermissions.includes(permission));
             const toRevoke = assignedPermissions.filter((permission) => !nextPermissions.includes(permission));
@@ -69,9 +69,7 @@ export default function UserPermissionsPage() {
                 await api.post(`users/${id}/permissions/revoke`, { permissions: toRevoke });
             }
         },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['user-permissions', id] });
-        },
+        invalidateQueries: [['user-permissions', id || '']],
     });
 
     const selected = new Set(assignedPermissions);

--- a/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/src/pages/admin/UsersPage.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { KeyRound, Shield, SquarePen, Trash2, User as UserIcon, UserPlus } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -33,11 +33,11 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import api from '@/lib/api';
+import { useApiMutation } from '@/lib/api-hooks';
 import type { User } from '@/types/models';
 
 export default function UsersPage() {
     const navigate = useNavigate();
-    const queryClient = useQueryClient();
     const { user: authUser } = useAuth();
     const [userToDelete, setUserToDelete] = useState<User | null>(null);
 
@@ -49,14 +49,12 @@ export default function UsersPage() {
         },
     });
 
-    const deleteMutation = useMutation({
+    const deleteMutation = useApiMutation({
         mutationFn: async (id: string) => {
             await api.delete(`users/${id}`);
         },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['users'] });
-            setUserToDelete(null);
-        },
+        invalidateQueries: [['users']],
+        onSuccess: () => setUserToDelete(null),
     });
 
     const isSuperadmin = authUser?.role === 'superadmin';

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -50,6 +50,7 @@ export const OrganizationSchema = z.object({
     settings: z.record(z.string(), z.unknown()).nullable().optional(),
     status: z.string().nullable().optional(),
     recording_policy: z.enum(['inherit', 'off', 'all', 'incoming', 'outgoing']).nullable().optional(),
+    recording_retention_days: z.number().nullable().optional(),
     max_extensions: z.number().nullable().optional(),
     max_concurrent_calls: z.number().nullable().optional(),
     max_dids: z.number().nullable().optional(),
@@ -289,6 +290,24 @@ export const RecordingSchema = z.object({
     updated_at: z.string(),
 });
 export type Recording = z.infer<typeof RecordingSchema>;
+
+// ─── Recording policy resolution ──────────────────────────────
+
+export const RecordingPolicyResolutionSchema = z.object({
+    resolved_mode: z.enum(['inherit', 'off', 'all', 'incoming', 'outgoing']),
+    should_record: z.boolean(),
+    winning_scope: z.enum(['organization', 'did', 'extension']).nullable(),
+    resolution_chain: z.array(z.string()),
+    reason: z.string(),
+});
+export type RecordingPolicyResolution = z.infer<typeof RecordingPolicyResolutionSchema>;
+
+export const EffectiveRecordingPolicySchema = z.object({
+    scope: z.enum(['organization', 'did', 'extension']),
+    inbound: RecordingPolicyResolutionSchema,
+    outbound: RecordingPolicyResolutionSchema,
+});
+export type EffectiveRecordingPolicy = z.infer<typeof EffectiveRecordingPolicySchema>;
 
 // ─── CDR ─────────────────────────────────────────────────────
 

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -272,6 +272,24 @@ export const FlowDefinitionSchema = z.object({
 });
 export type FlowDefinition = z.infer<typeof FlowDefinitionSchema>;
 
+// ─── Recordings ──────────────────────────────────────────────
+
+export const RecordingSchema = z.object({
+    id: idSchema,
+    organization_id: idSchema,
+    call_uuid: z.string().nullable().optional(),
+    file_name: z.string().nullable().optional(),
+    file_size: z.number().nullable().optional(),
+    format: z.string().nullable().optional(),
+    duration: z.number().nullable().optional(),
+    direction: z.string().nullable().optional(),
+    caller_id_number: z.string().nullable().optional(),
+    destination_number: z.string().nullable().optional(),
+    created_at: z.string(),
+    updated_at: z.string(),
+});
+export type Recording = z.infer<typeof RecordingSchema>;
+
 // ─── CDR ─────────────────────────────────────────────────────
 
 export const CdrSchema = z.object({
@@ -283,16 +301,44 @@ export const CdrSchema = z.object({
     caller_id_number: z.string().nullable().optional(),
     destination_number: z.string().nullable().optional(),
     direction: z.string().nullable().optional(),
+    call_type: z.string().nullable().optional(),
     duration: z.number().nullable().optional(),
     billsec: z.number().nullable().optional(),
     hangup_cause: z.string().nullable().optional(),
     start_stamp: z.string().nullable().optional(),
     answer_stamp: z.string().nullable().optional(),
     end_stamp: z.string().nullable().optional(),
+    recording_path: z.string().nullable().optional(),
+    has_recording: z.boolean().optional(),
+    recordings: z.array(RecordingSchema).default([]),
+    /** Present only when the call was traced through the delivery pipeline. */
+    call_session_id: idSchema.nullable().optional(),
     created_at: z.string(),
     updated_at: z.string(),
 });
 export type Cdr = z.infer<typeof CdrSchema>;
+
+/** Shape of `GET .../cdrs/analytics/summary`. */
+export interface CdrSummary {
+    total_calls: number;
+    answered_calls: number;
+    missed_calls: number;
+    failed_calls: number;
+    total_duration_seconds: number;
+    average_duration_seconds: number;
+    asr: number;
+    acd_seconds: number;
+}
+
+/** Laravel paginator metadata, as returned alongside `data`. */
+export interface PaginationMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
 
 // ─── Interaction Overview ────────────────────────────────────
 

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -302,10 +302,22 @@ export const RecordingPolicyResolutionSchema = z.object({
 });
 export type RecordingPolicyResolution = z.infer<typeof RecordingPolicyResolutionSchema>;
 
+export const InboundDidOverrideSchema = z.object({
+    id: idSchema,
+    number: z.string(),
+    recording_policy: z.enum(['inherit', 'off', 'all', 'incoming', 'outgoing']),
+});
+export type InboundDidOverride = z.infer<typeof InboundDidOverrideSchema>;
+
 export const EffectiveRecordingPolicySchema = z.object({
     scope: z.enum(['organization', 'did', 'extension']),
     inbound: RecordingPolicyResolutionSchema,
     outbound: RecordingPolicyResolutionSchema,
+    /**
+     * Numbers routed straight to this extension whose own policy overrides the
+     * extension's for calls arriving on them. Extension scope only.
+     */
+    inbound_did_overrides: z.array(InboundDidOverrideSchema).optional(),
 });
 export type EffectiveRecordingPolicy = z.infer<typeof EffectiveRecordingPolicySchema>;
 
@@ -329,7 +341,7 @@ export const CdrSchema = z.object({
     end_stamp: z.string().nullable().optional(),
     recording_path: z.string().nullable().optional(),
     has_recording: z.boolean().optional(),
-    recordings: z.array(RecordingSchema).default([]),
+    recordings: z.array(RecordingSchema).optional(),
     /** Present only when the call was traced through the delivery pipeline. */
     call_session_id: idSchema.nullable().optional(),
     created_at: z.string(),
@@ -337,14 +349,20 @@ export const CdrSchema = z.object({
 });
 export type Cdr = z.infer<typeof CdrSchema>;
 
-/** Shape of `GET .../cdrs/analytics/summary`. */
+/**
+ * Aggregate counters for a set of call records.
+ *
+ * `GET .../cdrs` returns this in `meta.summary`, computed from the same filters
+ * as the rows themselves, so KPI tiles above a filtered table describe that
+ * table. The analytics endpoint returns the same fields for a date range only.
+ */
 export interface CdrSummary {
     total_calls: number;
     answered_calls: number;
     missed_calls: number;
     failed_calls: number;
     total_duration_seconds: number;
-    average_duration_seconds: number;
+    total_billsec_seconds: number;
     asr: number;
     acd_seconds: number;
 }
@@ -357,6 +375,11 @@ export interface PaginationMeta {
     total: number;
     from: number | null;
     to: number | null;
+}
+
+/** Paginator metadata for `GET .../cdrs`, which carries the filtered summary. */
+export interface CdrPaginationMeta extends PaginationMeta {
+    summary?: CdrSummary;
 }
 
 // ─── Interaction Overview ────────────────────────────────────


### PR DESCRIPTION
Wave 1 of the UX review merged in #32. Mostly frontend against APIs that already existed and were already authorized, plus backend fixes where the data genuinely wasn't reachable — and, once the test suite could finally run end to end, a set of real production bugs it had been hiding.

## 1. Recordings had a complete API and zero UI

New Recordings page: filters (from/to number, date range), real pagination, inline playback, download, delete.

The playback path needed care. `recordings/{id}/download` sits behind Sanctum bearer auth and is served as an attachment, so `<audio src>` can't reach it — the browser sends no Authorization header. `RecordingPlayer` fetches a blob through the shared axios client on **first play only** (a 25-row page shouldn't pull 25 audio files), maps the stored `format` to a MIME type — an `octet-stream` response won't decode in some browsers — and revokes the object URL on unmount so paging doesn't leak every file played. A failed fetch stays retryable, and a blob whose row unmounts mid-download is released.

## 2. Call History had no phone numbers on it

It queried `/calls` (`CallSession`), which has no from/to/direction/duration at all — the direction cell was literally hardcoded `directionIcon(null)` with a "coming soon" comment. Repointed at `/cdrs`, which already carried everything:

- **Columns:** From (+ caller name), To, direction, started, **ring** and **talk** split, result, recording, journey link
- **Result** translates `hangup_cause` to plain language — "No answer", "Busy", "No such number" — with the raw cause on hover
- **Filters** bound to the existing `CdrSearchService` params; **CSV export** wired to the existing streaming endpoint; **real pagination**
- **KPI tiles** come from `meta.summary` on the list response, computed from the same filters as the rows. They previously derived from a single 15-row page, so "Total Calls" could never exceed 15 and silently lied.

Backend enablers: a `CallDetailRecord::callSession()` relation (joined on channel UUID, since CDRs come from FreeSWITCH and sessions from the delivery pipeline) so a row can still link to the interaction journey; `recordings` shaped through `RecordingResource` instead of dumped raw; a `has_recording` flag that falls back to `recording_path` so a call whose file hasn't been ingested yet shows "Pending" rather than nothing.

## 3. Effective recording policy is now visible

The resolver already returned `resolved_mode`, `winning_scope`, `resolution_chain` and a human `reason` — and threw them away. A read-only endpoint exposes the resolution per scope for both directions, and all three forms render it under the policy select:

```
GET organizations/{org}/recording-policy/effective
GET organizations/{org}/dids/{did}/recording-policy/effective
GET organizations/{org}/extensions/{extension}/recording-policy/effective
```

At extension scope, **inbound and outbound resolve through different DID layers**. The default outbound DID applies only to calls the extension places; an inbound call arrives on whichever number routed to it, so attributing the outbound DID to inbound advertised a policy that would never apply. Inbound resolves without a DID layer, and the numbers that *do* override it are listed separately as `inbound_did_overrides`.

Also: organization-scope **`Inherit` removed from the form** — it was offered where nothing exists to inherit from and silently resolved to `off`. The backend still accepts it so existing rows keep working. And **`recording_retention_days` is now visible and editable**; a cron permanently deletes recordings past it, but it was absent from the resource and every form, so the one control governing deletion was invisible.

## 4. One filter path instead of three

`CdrSearchService` now owns a single `applyFilters()`/`applySorting()` pair that the list, the summary, and the CSV export all run through. They had drifted:

- **The export silently dropped the `search` box.** Narrow the table to one caller, click Export CSV, and you got up to 50,000 unrelated calls.
- **A bare `YYYY-MM-DD` end date excluded the whole selected day.** `<= 2026-08-12` against a timestamp matches nothing on the 12th, so a single-day range looked empty. Fixed for CDR search, CDR export, and the recordings index via a shared `DateRangeFilter`.
- **The KPI tiles described a different set of calls than the table.** They came from the analytics endpoint, which only understands a date range and defaults to the last 30 days.
- **Recording number filters were exact-match**, so typing the digits you remember returned nothing.
- **`per_page` was ignored** by the extension and recording endpoints. Pickers that resolve an extension number to a name asked for 500, got 15, and labelled everything past the first page "Unknown extension".
- **Array query params returned 500** (`?date_to[]=x` reached a parser typed for `string`).

## 5. Permission and scoping fixes

- **Recording metadata leaked to anyone who could read call history.** The CDR eager load, `recording_path`, and `has_recording` now all follow the recordings permission — `RecordingPolicy` deliberately protects that data behind a separate grant.
- **Organization-scope checks run before authorization** on the CDR and recording-policy endpoints, so a record from another organization is absent rather than confirmed with a 403.
- **Outbound policy is resolved before connecting to FreeSWITCH.** A request rejected on policy grounds needed a reachable switch to be rejected at all, and returned without closing the connection it had opened.

## 6. Correctness fixes in the UI

- **Ten pages had `useMutation` with no `onError`** — a rejected organization delete showed nothing at all. All routed through the existing `useApiMutation` helper. `SipStatusPage` had five such mutations.
- **`Password: Hidden` could reach the clipboard.** The extension detail page rendered `{sip_password || 'Hidden'}` and the copy builder repeated it, so an admin could paste a non-working credential into an email while the toast reported success. The line is now omitted, the toast warns, and the write is awaited so a blocked clipboard doesn't report success either.
- **"Total Capacity"** rendered the extension count, not the capacity. Now "12 of 25 licensed" against `max_extensions`.
- **Devices list** showed a raw `extension_id` UUID in the column meant to answer "which line is this phone on". Now a linked extension number + owner, and "still loading" is distinguished from "extension no longer exists".
- Saving a number refetches its resolved policy; direction icons and loading spinners are exposed to assistive technology; `ui/pagination.tsx` moved to `ui/table-pagination.tsx` so the shadcn CLI can't overwrite it.

## ⚠️ The test suite had never run end to end — and that was hiding real bugs

The earlier note on this PR said the deny-by-default sweep from #33 was incomplete and that a full `artisan test` was the right next step. That run has now happened.

**Two things made the suite unrunnable, not just red:**

1. `CallOriginateApiTest` matched an originate command without the `origination_uuid` the service has emitted since `e0ea4c5`. The resulting Mockery exception escaped mid-request and left the `RefreshDatabase` transaction open, poisoning the shared SQLite connection — **430 cascading errors** across every test after it.
2. With that fixed, `InternalSipProfileWebRtcApiTest` stalled for minutes. Saving five SIP profile settings against an unreachable switch stacked 10s ESL connect timeouts across three retries per command. That is the WSS activation path, so it is a **production latency bug**, not a test annoyance.

**Result: 1399 tests, 4578 assertions, zero failures**, in about 90 seconds.

### Production bugs the run uncovered

- **Call flows were unmanageable for anyone below admin.** `FlowPolicy` checked `view-flows`/`manage-flows`; every other policy uses dotted slugs, `SyncPermissionsCommand` declares `flows.*`, and nothing declared the hyphenated pair — so those rows never existed. Deny-by-default turned that into a silent dead end. Same failure mode for `endpoint_bindings.*` (mobile and softphone bindings). Both fixed, and there is now a test comparing every slug a policy checks against every slug that can be created. Worth noting that test initially **missed** the flows case, because its pattern assumed dotted names — the guard is now shape-agnostic.
- **ESL `readBytes()` could spin forever.** A read timeout returns `''` with EOF still false, so the loop never terminated. `connect()` also assigned the socket before the handshake and could return `false` with the descriptor still open.
- **Unindexed foreign keys on `extensions`.** `default_outbound_did_id`, `default_outbound_gateway_id`, and `device_profile_id` had no usable index; Postgres does not index the referencing side of a foreign key, so resolving an extension's default DID or gateway meant a sequential scan, as did deleting a DID or gateway. `ForeignKeyIndexingTest` had been reporting this correctly — it was not a stale test.
- **The CDR summary ran six aggregate queries** on every paginated request, over what is typically the largest table in the schema. Now one query with conditional aggregates.

### How the stale tests were repaired

Each acting user is granted exactly the permissions its cases exercise, and each file gains a deny-path test so the requirement is *covered* rather than worked around. Roles were **not** raised to admin — that bypasses the policy and erases the check being tested.

Three tests asserted the removed allow-by-default rule outright (one comment read "Without explicit permission, hasPermission returns true (default-open)"). Those were **inverted**, not granted — granting there would have deleted coverage instead of updating it. Positive counterparts were added alongside each, so a policy hard-wired to `false` can't satisfy the negative case alone.

Two failures turned out to be validation, not permissions: DID update rejects any `destination_type` outside `extension|flow`, which the DID factory's random default hits ~60% of the time, and a webhook fixture used an extension number outside the default numbering range.

## Known issues, deliberately left alone

Both are pre-existing and outside this PR's scope, but a reviewer should know:

1. **`EventProcessor::handleChannelAnswer()` records `call.answered` for losing legs**, which flips `team_answered = true` regardless of which leg actually won. If anything derives "team answered" state from that flag, it is wrong.
2. **A DID whose destination is a ring group, IVR, time condition, or voicemail cannot be updated at all.** `UpdateDidRequest` accepts only `extension|flow`, while the factory and database carry five types — any such DID gets a 422 on save. Worked around in two tests; the endpoint itself is unchanged.

## Also worth a reviewer's eye

I **reverted** two `as unknown as Resolver<...>` casts added while working in these forms. They silenced a pre-existing zod-v4/`@hookform/resolvers` generics mismatch that affects ~8 forms; patching two inconsistently hides the problem while defeating the type checking you actually want on a form. Repo-wide error count is back to its baseline 99, all pre-existing. Worth its own cleanup PR.

`DidFormPage`'s `errorMap` → `error` fix was kept — that's a genuine zod-v4 API break in a file this PR touches, and it was blocking typecheck.

## Verification

- **Full backend suite: 1399 tests, 4578 assertions, OK** (host PHP 8.4, in-memory SQLite)
- `npm run build` succeeds; `tsc` error count verified identical to baseline (99, all pre-existing)
- `pint --test` clean across every PHP file this branch touches
- Docker was unavailable in this environment, so the suite ran against SQLite rather than Postgres. The new FK-index migration and the conditional-aggregate CDR summary are the two changes most worth re-running against Postgres, since both are database-engine specific.

## Not in this PR

Still open from Wave 1: the provisioning-health setup checklist (§7.1) and the Reports section over the existing analytics/supervisor-report/usage endpoints (§5.6). Both are frontend-only against shipped APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an organization-scoped Recordings page with filtering, playback, downloads, deletion, pagination, and retention information.
  * Added effective inbound and outbound recording-policy visibility for organizations, numbers, and extensions.
  * Added recording retention settings to organization administration.
  * Call History now provides searchable, filterable call records, summary metrics, recording access, and CSV export.
  * Device profiles now display assigned extension numbers and owner details.

* **Bug Fixes**
  * Recording and call data are now hidden unless the appropriate permissions are granted.
  * Improved date filtering, pagination, call validation, and handling of unavailable extension credentials.
  * Improved telephony connection timeout and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->